### PR TITLE
PDF export of cut sheets (CorelDraw import fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Generated SVG files
+# Generated SVG/PDF files
 output/*.svg
+output/*.pdf
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -332,7 +332,11 @@ this checklist is current.
    **red = engrave**, **gray text = ignore** (reference-only part/sheet
    labels — not a cut or engrave instruction). The "FAX MACHINE" letters
    are hatched engrave strokes, not filled shapes — engrave them at vector
-   (stroke) settings, same as the other red lines.
+   (stroke) settings, same as the other red lines. If the SVG import gets
+   mangled, run `.venv/bin/python scripts/export_pdf.py` to export
+   PDF versions of the sheets and coupon (same folder, same names) as a
+   fallback — the PDF page size matches each SVG's declared mm dimensions
+   exactly, so physical scale carries over.
 5. **Cut order: engrave first, then interior holes, then part outlines
    (inside-out), and set this explicitly** — don't assume the driver
    preserves file order. Engrave the red "FAX MACHINE" text and faceplate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
+    "cairosvg>=2.7",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/export_pdf.py
+++ b/scripts/export_pdf.py
@@ -1,0 +1,80 @@
+"""Export cut-ready SVG sheets to PDF (CorelDraw import fallback).
+
+NYC Resistor's workflow is CorelDraw X5-based, and their tips page warns
+that Inkscape's raw SVG export can get corrupted on import there --
+recommending PDF instead (see README "Cut day at NYC Resistor", step 4).
+This script converts each cut-ready sheet (output/sheet_*.svg) plus the kerf
+calibration coupon (output/kerf_coupon.svg) to a same-named PDF alongside it.
+
+Physical scale is the entire point: every source SVG declares its
+width/height in mm (see tests/svg_utils.py's get_svg_dimensions_mm, which
+gates this for the SVGs themselves), and cairosvg preserves those mm
+dimensions as the PDF page's MediaBox (1mm = 72/25.4 pt) as long as no
+output_width/output_height/scale override is passed -- CorelDraw honors the
+PDF page box, so this is what keeps the physical part sizes correct on
+import. Do not add scaling options here without re-verifying the MediaBox
+math (see tests exercising this, or re-derive by hand: mm * 72 / 25.4 = pt).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import cairosvg
+
+from faxbox.config import OUTPUT_DIR
+
+
+def _sheet_sort_key(path: Path) -> tuple[int, str]:
+    """Numeric sort for sheet_1.svg, sheet_2.svg, ... sheet_10.svg (not
+    lexicographic, which would put sheet_10 before sheet_2)."""
+    m = re.search(r"(\d+)", path.stem)
+    return (int(m.group(1)) if m else 0, path.name)
+
+
+def _cut_files(output_path: Path) -> list[Path]:
+    """Every cut-ready file this project sends to the laser: sheet_*.svg
+    (however many `layout.py` currently nests) plus the standalone kerf
+    coupon. Deliberately excludes final_layout.svg and the raw per-part
+    files (outer_shell.svg, drawer.svg, lids.svg) -- none of those are sent
+    for cutting (see layout.py's module docstring)."""
+    sheets = sorted(output_path.glob("sheet_*.svg"), key=_sheet_sort_key)
+    coupon = output_path / "kerf_coupon.svg"
+    files = list(sheets)
+    if coupon.exists():
+        files.append(coupon)
+    return files
+
+
+def export_pdfs() -> list[Path]:
+    """Convert every cut-ready SVG to a same-named PDF in output/.
+
+    Returns:
+        List of generated PDF paths, in the same order as the source SVGs.
+    """
+    output_path = Path(OUTPUT_DIR)
+    svg_files = _cut_files(output_path)
+    if not svg_files:
+        print(f"Error: no sheet_*.svg / kerf_coupon.svg found in {output_path.absolute()}")
+        print("Generate them first: .venv/bin/python -m faxbox.layout")
+        raise FileNotFoundError(f"No cut-ready SVGs in {output_path}")
+
+    pdf_paths: list[Path] = []
+    for svg_path in svg_files:
+        pdf_path = svg_path.with_suffix(".pdf")
+        cairosvg.svg2pdf(url=str(svg_path), write_to=str(pdf_path))
+        pdf_paths.append(pdf_path)
+
+    print(f"Exported {len(pdf_paths)} PDF(s) to {output_path.absolute()}:")
+    for pdf_path in pdf_paths:
+        print(f"  {pdf_path.name}")
+    print(
+        "Physical scale is preserved (PDF page box = SVG's declared mm size); "
+        "use these as the CorelDraw import fallback if raw SVG import mangles a sheet."
+    )
+    return pdf_paths
+
+
+if __name__ == "__main__":
+    export_pdfs()


### PR DESCRIPTION
## Summary
- Adds `scripts/export_pdf.py`, converting `output/sheet_*.svg` (however many `layout.py` nests) and `output/kerf_coupon.svg` to same-named PDFs via `cairosvg`, as the fallback for NYC Resistor's CorelDraw X5 SVG import (HANDOFF.md step 3).
- Physical scale is preserved: cairosvg's default conversion uses each SVG's declared mm width/height directly as the PDF page box, with no scale/output_width overrides.
- Adds `cairosvg>=2.7` to the `dev` extra in `pyproject.toml`; ignores `output/*.pdf` in `.gitignore` (mirrors the existing `output/*.svg` rule).
- README's "Cut day" checklist item 4 (CorelDraw import) now mentions the script as the fallback.

## Verification
Ran `.venv/bin/python scripts/export_pdf.py`, then compared each PDF's MediaBox (via `pdfinfo`, converted pt → mm at 72/25.4) against the source SVG's declared mm size, tolerance 0.1mm:

| file | SVG (mm) | PDF (mm) | diff (mm) |
|---|---|---|---|
| sheet_1 | 553.500 x 355.520 | 553.501 x 355.519 | 0.0013, 0.0011 |
| sheet_2 | 548.720 x 433.480 | 548.721 x 433.479 | 0.0011, 0.0008 |
| sheet_3 | 548.980 x 249.640 | 548.979 x 249.640 | 0.0013, 0.0000 |
| kerf_coupon | 110.160 x 45.160 | 110.160 x 45.160 | 0.0002, 0.0001 |

All well within tolerance. Also rasterized `sheet_1.pdf` back to PNG (`pdftoppm`) and visually confirmed blue cut lines, finger joints, and gray reference labels survived (not blank).

Full suite: `.venv/bin/python -m pytest tests/ -q` → **164 passed**, both before and after this change (baseline confirmed green before starting; no test was weakened).

## Test plan
- [x] `pytest tests/ -q` green before change (164 passed)
- [x] `scripts/export_pdf.py` generates 4 PDFs alongside the SVGs
- [x] MediaBox vs. SVG mm size verified within 0.1mm tolerance (see table above)
- [x] One PDF rendered back to PNG and visually inspected for content
- [x] `pytest tests/ -q` green after change (164 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvRaq1ibcFkT1fSc7P8E8W