### PR TITLE
[experimental] iter2: lid + drawer spring-detent retention (#20)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -197,9 +197,11 @@ are the right wall's mirrored in X. Engraving goes on the right wall only.
 - Grip: rounded through-slot **30 × 10, r = 5**, centered in Y, slot center
   25mm from the front edge (10mm ligament to the edge; at 15mm the ligament
   was ~0.2mm and would have broken into a notch — red-team finding).
-- No retention along the travel axis: the divider stops rearward motion but
-  nothing stops the lid sliding out the front when the box tips forward.
-  Accepted cost of the front-insert decision; carry the box level.
+- ~~No retention along the travel axis~~ **Superseded by "Retention (iteration
+  2)" below (issue #20):** each side wall now carries a cantilever spring
+  detent whose nub pops through a matching notch cut into the lid's side
+  edges when closed, holding the lid seated at a 90° front-down tip. The
+  slide is still free-running otherwise — this is a detent, not a lock.
 
 ### 9. Drawers — 2× identical, 6 pieces each
 
@@ -213,8 +215,10 @@ Body = open-top finger-jointed box, captive bottom:
   drawer's in-stop** (the inset faceplate never bears on the rear-wall frame;
   red-team finding). Closed, the faceplate sits recessed by the 0.475 slide
   gap — near-flush, since true flush and slide clearance are mutually
-  exclusive. There is no out-retention: a drawer slides free if the box is
-  tipped rear-down.
+  exclusive. ~~There is no out-retention~~ **Superseded by "Retention
+  (iteration 2)" below (issue #20):** each faceplate now carries a cantilever
+  spring detent per Y edge whose nub snaps behind the rear-wall opening's
+  side edge on close, holding the drawer seated at a 90° rear-down tip.
 - Lateral play in the bay is ~4.9mm/side by design — the drawer is guided by
   its opening, not the bay walls; max skew ≈ 1.3°, acceptable for a first cut.
 
@@ -222,7 +226,11 @@ Faceplate (6th piece), glued to the body front:
 
 - Blank: **150.9 (Y) × 53.5 (Z)** = opening − 2 × 0.75 reveal; covers the body
   cross-section exactly in height, +0.95/side in width; flush with the rear
-  face when closed (faceplate thickness T fills the rear wall plane).
+  face when closed (faceplate thickness T fills the rear wall plane). As of
+  iteration 2 (issue #20), the DRAWN/cut blank is wider than this: see
+  "Retention (iteration 2)" below — the retention nubs make the true drawn
+  width 150.9 + 2×DRAWER_DETENT_PROTRUDE (153.3), protruding past this
+  nominal footprint by design.
 - **Grip slot**: closed rounded slot **30 × 15, r = 7.5**, cut through BOTH
   the faceplate and the body's front wall, aligned, so a finger hooks through
   into the drawer. Centered in Y; slot top edge 8.0 below the part's top edge
@@ -243,6 +251,129 @@ Faceplate (6th piece), glued to the body front:
 | Lid thickness ↔ slot height | 0.8 | = 0.8 (documented deviation) |
 | Faceplate ↔ opening | 0.75/side | reveal 0.5–1.0 |
 | Webs in rear wall | 3.175 / 3.7375 | ≥ 3.0 |
+| Lid detent nub ↔ slot ceiling | ≥ 1.0 | nub top (Z 119.525) clears slot top (122.0) |
+| Faceplate nub ↔ opening (per side) | 0.45 interference | protrusion (1.2) − reveal (0.75) |
+
+## Retention (iteration 2, issue #20)
+
+Two in-plane laser-cut cantilever spring detents, adapted from Boxes.py's own
+precedents (`boxes/edges.py` `SlideOnLidSettings`/`LidRight`: spring length
+`min(6t, ...)`, 30° tip ramp, 0.4t catch depth; `boxes/generators/
+dinrailbox.py`: a cantilever tongue with a nub cut into a panel). This
+project adapts their *proportions*, not their play values — those precedents
+assume ~0.3mm clearance; this design's slide clearances (`SLIDE_CLEARANCE` =
+1.5, `LID_SLOT_VERTICAL_CLEARANCE` = 0.8) are deliberately looser, so the
+nub/notch interference has to do more work to stay engaged through that play.
+All new geometry is driven from `src/faxbox/config.py` constants (see that
+file's "Retention (iteration 2, issue #20)" section) via shared point-
+generation helpers in `src/faxbox/detent.py` — no magic numbers in the
+generators.
+
+**Shared cantilever proportions** (both mechanisms): beam length 18.0mm,
+beam cross-section width 2.5mm in the flex direction, root fillet ≥1.0mm,
+≥2.5mm clearance behind/below the beam so it can deflect its engagement
+depth without bottoming out, 30° ramp angle (matching `LidRight`'s barb
+angle), 1.0mm release-cut width to fully part the beam's free tip from the
+surrounding material. All shapes are drawn **burn-neutral** (raw ctx path,
+no Boxes.py burn compensation) — a deliberate simplification, since the two
+interference values below are explicitly meant to be tuned against the
+retention coupon (see `src/faxbox/calibration.py`'s `RetentionCoupon`)
+before cutting real parts; kerf's ~0.1–0.2mm effect is small next to the
+1.2–1.5mm interference margins.
+
+### A. Side-wall lid detent
+
+- Cut into EACH side wall, just below the lid slot floor (Z = 118.025): a
+  cantilever beam running parallel to X, Z-span 115.525 → 118.025 (2.5mm
+  wide), with a clearance cavity below it (Z 113.025 → 115.525) and a 1.0mm
+  severing slot at its free (tip) end — see `faxbox.detent.release_cut_rects`.
+  The root end (deeper into the wall) is left solid.
+- Beam spans box X 11.0 → 29.0 (`LID_DETENT_TIP_X` → `LID_DETENT_ROOT_X`,
+  18mm, centered on `LID_DETENT_X` = 20.0) — clear of the front-edge finger
+  joints (a vertical edge feature, unrelated to this X range) and ≥40mm from
+  the divider hole line (79.375–82.55).
+- The nub is a ramped bump built into the lid-slot hole's own bottom
+  boundary (`faxbox.detent.lid_slot_with_nub_points`), centered at
+  `LID_DETENT_X`, rising from the slot floor (118.025) to `LID_DETENT_NUB_TOP_Z`
+  = 119.525 (1.5mm rise — exceeds the 0.8mm lid vertical play so the nub
+  stays engaged when the box tips and the lid shifts within its play). Top
+  clears the 122.0 slot ceiling by 2.475mm. Ramped on both X-faces at 30°,
+  with a 2.5mm flat top (a flat land rather than a knife edge, since a bare
+  wedge would concentrate stress in cross-grain plywood — see the Grain
+  caveat below); base width ≈7.7mm (`LID_DETENT_NUB_BASE_WIDTH`).
+- **Mating notch in the lid's side edges** (both long edges, one per wall):
+  an edge-open recess (`faxbox.detent.notch_points`) at lid-local X =
+  `LID_NOTCH_X` = 19.625 (= `LID_DETENT_X` − `LID_CLOSED_FRONT_X`, where
+  `LID_CLOSED_FRONT_X` = 0.375 is the closed lid's front-edge offset from
+  the box's front face — DESIGN.md #8). Width ≈8.7mm (nub base + 1mm), depth
+  3.0mm (exceeds the lid's 2.425mm slot engagement with margin), mouth
+  corners eased by a 1.0mm chamfer. When closed, the nub pops up through the
+  notch: positive retention at a 90° front-down tip.
+- Both walls are mirror images (per the existing convention: drawn
+  exterior-face-up, left wall mirrored in local X) — the nub, release cut,
+  and lid-slot-with-nub polygon are all mirrored the same way the plain slot
+  already was, landing both walls' nubs at the same real box X.
+
+### B. Drawer faceplate detent
+
+- Cut into EACH faceplate, near BOTH Y side edges: a vertical cantilever
+  (along Z), 18mm long, Z-span 17.75 → 35.75 (`DRAWER_DETENT_ROOT_Z` →
+  `DRAWER_DETENT_TIP_Z`, centered on `DRAWER_DETENT_Z` = 26.75, the
+  faceplate's mid-height), 2.5mm wide in the flex direction, with the same
+  clearance-cavity + severing-slot release cut as mechanism A (transposed:
+  "along" is Z, "across" is the faceplate's drawn-x).
+- The nub protrudes `DRAWER_DETENT_PROTRUDE` = 1.2mm beyond the faceplate's
+  nominal edge (0.45mm interference past the 0.75mm `FACEPLATE_REVEAL` when
+  centered in its opening), ramped at 30° on both Y-faces with a 2.5mm flat
+  top, base width ≈6.66mm (`DRAWER_DETENT_NUB_BASE_WIDTH`).
+- Because this nub protrudes past the faceplate's own outer edge (there is
+  no pre-existing void to poke into, unlike mechanism A's lid slot), the
+  faceplate's outer boundary is hand-drawn (`faxbox.detent.edge_nub_detour`)
+  instead of Boxes.py's automatic straight "e" edges, which can't express a
+  local protrusion. This makes the faceplate's true drawn/measured footprint
+  `FACEPLATE_DRAWN_WIDTH` = 150.9 + 2×1.2 = 153.3mm rather than the plain
+  150.9mm nominal — **flagged deviation**: this legitimately changed
+  `tests/test_svg_geometry.py::test_faceplate_blank_size`'s measured
+  quantity (see that test's comment) and, since the faceplate no longer
+  calls `rectangularWall(..., "eeee", ...)` at all,
+  `test_edge_polarity_literals_present`'s literal count. Both were the
+  minimal, unavoidable, documented consequence of adding a REAL protruding
+  interference feature — there is no way to add retention here without the
+  physical part becoming physically bigger at the nub, and svg_utils's
+  bbox-based piece detection can't distinguish that from "a bigger nominal
+  blank" for the same connected outer path.
+- Grip slot (Y-centered, ~60mm from either edge) and the nub (near each Y
+  edge, Z-centered at mid-height) never intersect — their Y ranges are
+  disjoint regardless of Z overlap.
+- Snaps past the rear-wall opening's side edge on close (the opening's
+  interior corner, 3.175mm deep per DESIGN.md #4); the grip-slot pull cams
+  it back through on deliberate removal.
+
+### Grain caveat
+
+Plywood cantilevers are ~3× weaker bending across the face-veneer grain than
+with it (SpringFit, UIST 2019). `layout.py`'s shelf packer never rotates
+parts — each piece keeps the same X/Y orientation from its source SVG onto
+the sheet — and this project assumes **grain runs along the sheet's long
+(X) axis** (already README's cut-day guidance: "Orient sheets with the face
+grain running along the sheet's long axis"). Under that assumption:
+
+- **Mechanism A (side wall)** is grain-favorable: the wall's long axis
+  (298.45mm, local X) maps directly to the sheet's long axis with no
+  rotation, and the beam's length (also along X) runs *with* the grain —
+  the bending fibers at the beam's root are parallel to grain.
+- **Mechanism B (faceplate)** is grain-adverse: the faceplate's long axis
+  (150.9mm, local X = box Y) also maps to the sheet's long axis, but the
+  beam runs *perpendicular* to it (along Z) — the beam bends *across* grain,
+  the weaker direction.
+
+This is exactly why the retention coupon (`faxbox.calibration.RetentionCoupon`,
+`output/retention_coupon.svg`) exists: cut both flexure samples on real stock
+oriented the same way the real parts will be, and confirm the faceplate
+sample's snap force is still adequate (not brittle) before committing to
+DRAWER_DETENT_PROTRUDE = 1.2 on the real faceplates. If it proves too weak,
+the documented fallback is magnets (issue #20's "Ideas to evaluate") rather
+than forcing a larger interference that risks a snapped-off nub.
 
 ## Known deltas from SPEC.md targets
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -282,17 +282,47 @@ axis X *and* the deflection axis Z, so its ramps genuinely cam against
 motion along X).
 
 **Shared cantilever proportions**: beam cross-section width 2.5mm in the
-flex direction (`DETENT_BEAM_WIDTH`), root fillet ≥1.0mm, ≥2.5mm clearance
-behind the beam so it can deflect its engagement depth without bottoming
-out (`DETENT_CLEARANCE`), 30° ramp angle (`DETENT_RAMP_DEG`), 1.0mm
-release-cut width to fully part the beam's free tip from the surrounding
-material (`DETENT_SEVER_WIDTH`), and `DETENT_SEVER_CLEARANCE` = 1.5mm kept
-between a nub's own (ramped) base edge and its release/sever cut, so the
-sever cut cannot undercut the nub's own base and leave it bridged to the
-fixed material on its outward side (this was verified against the ACTUAL
-drawn geometry, not assumed — see the "nub bridging" note below). Beam
-length differs per mechanism (see each below), driven by the strain
-formula, not a shared constant.
+flex direction (`DETENT_BEAM_WIDTH`), root fillet ≥1.0mm, 30° ramp angle
+(`DETENT_RAMP_DEG`), 1.0mm release-cut width to fully part the beam's free
+tip from the surrounding material (`DETENT_SEVER_WIDTH`), and
+`DETENT_SEVER_CLEARANCE` = 1.5mm kept between a nub's own (ramped) base
+edge and its release/sever cut, so the sever cut cannot undercut the nub's
+own base and leave it bridged to the fixed material on its outward side
+(this was verified against the ACTUAL drawn geometry, not assumed — see
+the "nub bridging" note below). Beam length differs per mechanism (see
+each below), driven by the strain formula, not a shared constant.
+
+**Clearance cavity depth is now PER-MECHANISM, not shared** (FIX, issue #20
+pass-3 red-team F3): a single shared `DETENT_CLEARANCE` (2.5mm) used to size
+the clearance behind/above BOTH beams, sized only to each mechanism's own
+nub engagement depth. That undercounts how far the beam's FREE TIP actually
+rises, because in both mechanisms the nub sits near, but not exactly at,
+the beam's severed free end (`DETENT_SEVER_CLEARANCE` keeps a gap between
+the nub's own base and the sever cut) — the tip therefore overhangs past
+the nub's own load point, and by ordinary cantilever beam theory a point
+further past a load rises MORE than the load point itself:
+
+**tip rise = engage · (1 + 3·overhang / (2·span))**
+
+(`overhang` = distance from the nub's load point to the beam's true
+severed free tip; `span` = root-to-nub distance; see `config._tip_rise`).
+Each mechanism's cavity must be **≥ its own tip rise + 0.5mm real margin**,
+computed via this formula, not assumed equal to the nub's own engagement:
+
+- **Mechanism A (lid, side wall)**: overhang ≈4.85mm, span = 22.0mm ⇒ tip
+  rise ≈2.00mm ⇒ `LID_DETENT_CAVITY` = 2.00 + 0.5 = **2.5mm** — unchanged
+  from the old shared value. This mechanism's proportions happened to keep
+  the tip rise within the old cavity's margin; the formula makes that
+  margin explicit instead of accidental.
+- **Mechanism B (drawer, side wall)**: overhang ≈6.06mm, span = 26.0mm ⇒
+  tip rise ≈2.97mm, which EXCEEDS the old shared 2.5mm cavity — the beam
+  would bind against the cavity's far wall at ≈1.85mm of nub lift, short of
+  the designed 2.2mm engagement. `DRAWER_DETENT_CAVITY` = 2.97 + 0.5 =
+  **≈3.47mm** fixes this. Checked against the drawer side's own 53.5mm
+  total height (DESIGN.md #9): the deeper cavity's far edge sits well
+  short of the panel's own top edge and every other feature, with no web
+  thinner than `MIN_WEB` (3.0mm) introduced — confirmed both by the
+  measured constants and by rendering `drawer.svg`.
 
 **Burn (FIX3, red-team)**: every nub/notch/detour shape is drawn
 BURN-compensated (see `faxbox.detent`'s module docstring for the exact
@@ -393,12 +423,42 @@ always sound — it's an X-Z part); only the strain (below) was refit.
   fully finger-jointed to the drawer's own Bottom panel along its whole
   length; a Boxes.py finger-joint edge can't locally express the nub's
   protrusion (the same limitation the removed faceplate detent hit), so a
-  short PLAIN zone (`DRAWER_DETENT_PLAIN_LO` ≈ 15.44 → `..._PLAIN_HI` =
+  short PLAIN zone (`DRAWER_DETENT_PLAIN_LO` ≈ 9.44 → `..._PLAIN_HI` =
   52.0) replaces the finger joint there via a 3-segment CompoundEdge
   (finger / purpose-built nub edge / finger — see
   `generate_drawers.py`'s `_DrawerFlexureNubEdge`). The Bottom panel's own
   matching finger-hole row is split to skip the same X-range, so there are
-  no unplugged holes.
+  no unplugged holes. (`PLAIN_LO` moved from ≈15.44 to ≈9.44 as part of the
+  bottom-panel clearance slot fix below — the slot is wider than the
+  beam's own tip-to-root span, so it, not the beam, now sets this bound.)
+- **Bottom-panel clearance slot** (FIX, issue #20 pass-3 red-team F2,
+  CRITICAL): the drawer's own Bottom panel sits flush across the drawer's
+  FULL exterior footprint (DESIGN.md #9), directly beneath the flexure
+  zone — before this fix, that panel was solid there, but the nub needs to
+  reach `DRAWER_DETENT_ENGAGE` (2.2mm) PAST it to do anything useful (skipping
+  the finger-hole ROW there, as described above, only removes the row's
+  individual tab-holes; it does nothing to open the panel's own solid
+  field to the nub's swept path). At the nub's WIDEST cross-section — the
+  wall plane, where the nub is still flush with the wall's bulk material,
+  `NUB_WIDTH_AT_WALL_PLANE` ≈ 21.1mm nominal (≈21.4mm as-cut with BURN) —
+  the panel had nowhere for the nub to go. Fix: one rectangular clearance
+  hole per side wall, cut through the drawer's Bottom panel
+  (`generate_drawers.py`'s `_build_bottom`), sized to:
+  - X-length (`DRAWER_BOTTOM_SLOT_X_LENGTH` ≈ 23.1mm): `NUB_WIDTH_AT_WALL_PLANE`
+    + 1mm margin on each end, centered on the nub (box X = T +
+    `DRAWER_DETENT_NUB_X`).
+  - Y-span (`DRAWER_BOTTOM_SLOT_Y_SPAN` ≈ 3.675mm): the wall's own seat
+    zone (0 → T) + 0.5mm inboard margin — starts exactly at the panel's
+    true edge (nothing is lost outboard of the wall's own footprint) and
+    extends 0.5mm inboard for real clearance.
+  Because this slot is WIDER than the flexure beam's own tip-to-root span,
+  `DRAWER_DETENT_PLAIN_LO`/`..._PLAIN_HI` (above) are now sized to whichever
+  requirement is wider on each side — the slot's own X-extent + 3mm margin
+  (so the slot doesn't clip the finger-hole row's own teeth where it
+  resumes, the same principle `CATCH_HOLE_PLAIN_MARGIN` applies to the
+  catch holes below), or the beam's tip-to-root span + 2mm, whichever is
+  wider. Hidden under the drawer once assembled (cosmetic underside
+  cutout, same visibility caveat as the catch holes below).
 - **Kinematics**: on insertion, the drawer (faceplate trailing) has its nub
   cam UP over the rear-wall opening's own sill web (the T=3.175mm-thick
   rear-wall material below the bottom opening / above the top opening's
@@ -417,8 +477,23 @@ always sound — it's an X-Z part); only the strain (below) was refit.
     drawer body length, per the fix's own instruction, landing at
     `CATCH_HOLE_X` ≈ 273.975 (≈24mm in from the rear wall's interior face —
     matches the drawer's remaining travel after the nub clears the sill).
-  - X-length: `CATCH_HOLE_X_LENGTH` = nub base width + 0.8mm, keeping
-    engaged X-slop ≤ 0.8mm.
+  - X-length: `CATCH_HOLE_X_LENGTH` = `NUB_WIDTH_AT_FLOOR_PLANE` + 0.8mm,
+    keeping engaged X-slop ≤ 0.8mm nominal (≈0.5mm real engaged slop, per
+    the independent-datum registration test below). **Nub width naming
+    fix (FIX, issue #20 pass-3 red-team F4)**: the taper is linear
+    (constant `DETENT_RAMP_DEG`), so its half-width simply grows with
+    depth traveled back up the ramp from the narrow tip — this means the
+    nub has a DIFFERENT width at every Z/Y level along its length, and the
+    previous revision's `DRAWER_DETENT_NUB_BASE_WIDTH` (≈10.12) was
+    measured at the FLOOR plane (`DRAWER_DETENT_ENGAGE` above the tip —
+    the cross-section that actually threads through this catch hole) while
+    being *named* as if it were the nub's "base" (i.e. its widest point, at
+    the wall plane, ≈21.1mm nominal / ≈21.4mm as-cut — see the
+    bottom-panel clearance slot, above, which DOES need that wider value).
+    Renamed to two explicit, correctly-scoped constants:
+    `NUB_WIDTH_AT_FLOOR_PLANE` (≈10.12, unchanged value — used here, for
+    catch-hole sizing) and `NUB_WIDTH_AT_WALL_PLANE` (≈21.1, new — used for
+    the bottom-panel clearance slot).
   - Y-width: `CATCH_HOLE_Y_WIDTH` = T (side thickness) + 2×`DRAWER_LATERAL_GAP`
     (the drawer's own ~4.9mm/side bay float) + 1mm margin ≈ 13.925mm, so the
     nub can't miss the hole even at worst-case drawer skew.
@@ -435,6 +510,21 @@ always sound — it's an X-Z part); only the strain (below) was refit.
     worst-case skew, which is the failure mode this hole exists to prevent.
   - Visible from the box underside when the drawer is out (bottom panel
     only) — cosmetic, accepted.
+  - **Registration test (FIX, issue #20 pass-3 red-team F4, CRITICAL)**:
+    prior to this fix, no test verified the catch hole and the nub actually
+    land at the same box X end-to-end — a red-team mutation
+    (`CATCH_HOLE_X += 5.0`) stayed green against every existing test,
+    since none of them independently recomputed one side's expected
+    position from the other. `tests/test_retention.py::
+    test_catch_hole_registers_with_nub_via_independent_datums` now
+    measures the drawer's own Bottom-panel clearance slot (above, F2 —
+    a plain, un-jointed hole with zero tab-position ambiguity, unlike the
+    jointed side panel the nub itself is cut into) as an independent proxy
+    for the nub's true position, combines it with the rear-wall plane
+    (`BAY_X1`) and a MEASURED (not config-echoed) drawer body length, and
+    asserts the shell's catch hole X-span contains the computed nub X-span
+    with ≤1.0mm total slop — parsed entirely from the generated SVGs, not
+    by comparing config constants to themselves.
 - Grip slot (Y-centered) and the flexure zone (near each side panel's front
   end) never intersect.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -197,11 +197,11 @@ are the right wall's mirrored in X. Engraving goes on the right wall only.
 - Grip: rounded through-slot **30 × 10, r = 5**, centered in Y, slot center
   25mm from the front edge (10mm ligament to the edge; at 15mm the ligament
   was ~0.2mm and would have broken into a notch — red-team finding).
-- ~~No retention along the travel axis~~ **Superseded by "Retention (iteration
-  2)" below (issue #20):** each side wall now carries a cantilever spring
-  detent whose nub pops through a matching notch cut into the lid's side
-  edges when closed, holding the lid seated at a 90° front-down tip. The
-  slide is still free-running otherwise — this is a detent, not a lock.
+- ~~No retention along the travel axis~~ **Superseded by "Retention" below
+  (issue #20):** each side wall carries a cantilever spring detent whose nub
+  pops through a matching notch cut into the lid's side edges when closed,
+  holding the lid seated at a 90° front-down tip. The slide is still
+  free-running otherwise — this is a detent, not a lock.
 
 ### 9. Drawers — 2× identical, 6 pieces each
 
@@ -215,10 +215,12 @@ Body = open-top finger-jointed box, captive bottom:
   drawer's in-stop** (the inset faceplate never bears on the rear-wall frame;
   red-team finding). Closed, the faceplate sits recessed by the 0.475 slide
   gap — near-flush, since true flush and slide clearance are mutually
-  exclusive. ~~There is no out-retention~~ **Superseded by "Retention
-  (iteration 2)" below (issue #20):** each faceplate now carries a cantilever
-  spring detent per Y edge whose nub snaps behind the rear-wall opening's
-  side edge on close, holding the drawer seated at a 90° rear-down tip.
+  exclusive. ~~There is no out-retention~~ **Superseded by "Retention"
+  below (issue #20):** each of the two SIDE panels (not the faceplate — see
+  the red-team note below) carries a cantilever spring-detent flexure near
+  its front (faceplate) end, whose nub snaps into a catch hole cut through
+  the bottom panel (bottom drawer) or shelf (top drawer) at the closed
+  position, holding the drawer seated.
 - Lateral play in the bay is ~4.9mm/side by design — the drawer is guided by
   its opening, not the bay walls; max skew ≈ 1.3°, acceptable for a first cut.
 
@@ -226,11 +228,14 @@ Faceplate (6th piece), glued to the body front:
 
 - Blank: **150.9 (Y) × 53.5 (Z)** = opening − 2 × 0.75 reveal; covers the body
   cross-section exactly in height, +0.95/side in width; flush with the rear
-  face when closed (faceplate thickness T fills the rear wall plane). As of
-  iteration 2 (issue #20), the DRAWN/cut blank is wider than this: see
-  "Retention (iteration 2)" below — the retention nubs make the true drawn
-  width 150.9 + 2×DRAWER_DETENT_PROTRUDE (153.3), protruding past this
-  nominal footprint by design.
+  face when closed (faceplate thickness T fills the rear wall plane). Plain
+  edges (glued, not finger-jointed) — **this is the exact original (v1)
+  blank.** Issue #20's first iteration briefly gave the faceplate a
+  retention nub of its own (a wider drawn/cut blank); red-team review found
+  that mechanism geometrically impossible (a Y-Z plate can't cam against
+  X-axis drawer travel — see "Retention" below) and it was removed, so the
+  faceplate carries **no retention feature at all**. Retention for the whole
+  drawer now lives entirely in the SIDE panels (above).
 - **Grip slot**: closed rounded slot **30 × 15, r = 7.5**, cut through BOTH
   the faceplate and the body's front wall, aligned, so a finger hooks through
   into the drawer. Centered in Y; slot top edge 8.0 below the part's top edge
@@ -252,102 +257,201 @@ Faceplate (6th piece), glued to the body front:
 | Faceplate ↔ opening | 0.75/side | reveal 0.5–1.0 |
 | Webs in rear wall | 3.175 / 3.7375 | ≥ 3.0 |
 | Lid detent nub ↔ slot ceiling | ≥ 1.0 | nub top (Z 119.525) clears slot top (122.0) |
-| Faceplate nub ↔ opening (per side) | 0.45 interference | protrusion (1.2) − reveal (0.75) |
+| Drawer detent nub ↔ opening vertical play | ≥ 0.7 | engage (2.2) − opening play (1.5) |
+| Catch-hole engaged X-slop | ≤ 0.8 | hole length (10.92) − nub base width (10.12) |
 
-## Retention (iteration 2, issue #20)
+## Retention (iteration 3, issue #20 red-team)
 
-Two in-plane laser-cut cantilever spring detents, adapted from Boxes.py's own
-precedents (`boxes/edges.py` `SlideOnLidSettings`/`LidRight`: spring length
-`min(6t, ...)`, 30° tip ramp, 0.4t catch depth; `boxes/generators/
-dinrailbox.py`: a cantilever tongue with a nub cut into a panel). This
-project adapts their *proportions*, not their play values — those precedents
-assume ~0.3mm clearance; this design's slide clearances (`SLIDE_CLEARANCE` =
-1.5, `LID_SLOT_VERTICAL_CLEARANCE` = 0.8) are deliberately looser, so the
-nub/notch interference has to do more work to stay engaged through that play.
-All new geometry is driven from `src/faxbox/config.py` constants (see that
-file's "Retention (iteration 2, issue #20)" section) via shared point-
-generation helpers in `src/faxbox/detent.py` — no magic numbers in the
-generators.
+Two in-plane laser-cut cantilever spring detents. All geometry is driven
+from `src/faxbox/config.py` constants (see that file's "Retention
+(iteration 3, issue #20 red-team)" section) via shared point-generation
+helpers in `src/faxbox/detent.py` — no magic numbers in the generators.
 
-**Shared cantilever proportions** (both mechanisms): beam length 18.0mm,
-beam cross-section width 2.5mm in the flex direction, root fillet ≥1.0mm,
-≥2.5mm clearance behind/below the beam so it can deflect its engagement
-depth without bottoming out, 30° ramp angle (matching `LidRight`'s barb
-angle), 1.0mm release-cut width to fully part the beam's free tip from the
-surrounding material. All shapes are drawn **burn-neutral** (raw ctx path,
-no Boxes.py burn compensation) — a deliberate simplification, since the two
-interference values below are explicitly meant to be tuned against the
-retention coupon (see `src/faxbox/calibration.py`'s `RetentionCoupon`)
-before cutting real parts; kerf's ~0.1–0.2mm effect is small next to the
-1.2–1.5mm interference margins.
+**Why iteration 2's drawer mechanism was replaced.** Iteration 2 put a
+retention nub on the faceplate (a Y-Z plate — its plane contains Y and Z,
+not X). The drawer travels along X, *normal* to that plate. A laser-cut
+edge is square through the material's thickness, so a "ramp" drawn on a Y-Z
+part's boundary is a ramp in the Y-Z plane — it is never swept by motion
+along X. The faceplate nub could only ever meet the rear-wall opening frame
+as a **square 0.45mm interference** (a jam, not a cam) — there was no
+physical path for it to cam past anything on insertion. This was caught by
+red-team review before cutting; the fix is a different mechanism entirely,
+not a retuned version of the same one. Mechanism B below replaces it,
+cut into the drawer's SIDE walls (an X-Z plane — it contains the travel
+axis X *and* the deflection axis Z, so its ramps genuinely cam against
+motion along X).
+
+**Shared cantilever proportions**: beam cross-section width 2.5mm in the
+flex direction (`DETENT_BEAM_WIDTH`), root fillet ≥1.0mm, ≥2.5mm clearance
+behind the beam so it can deflect its engagement depth without bottoming
+out (`DETENT_CLEARANCE`), 30° ramp angle (`DETENT_RAMP_DEG`), 1.0mm
+release-cut width to fully part the beam's free tip from the surrounding
+material (`DETENT_SEVER_WIDTH`), and `DETENT_SEVER_CLEARANCE` = 1.5mm kept
+between a nub's own (ramped) base edge and its release/sever cut, so the
+sever cut cannot undercut the nub's own base and leave it bridged to the
+fixed material on its outward side (this was verified against the ACTUAL
+drawn geometry, not assumed — see the "nub bridging" note below). Beam
+length differs per mechanism (see each below), driven by the strain
+formula, not a shared constant.
+
+**Burn (FIX3, red-team)**: every nub/notch/detour shape is drawn
+BURN-compensated (see `faxbox.detent`'s module docstring for the exact
+model), matching how the rest of the box already compensates finger joints
+and holes for kerf — pre-iteration-3, these shapes were burn-*neutral*
+while their own release cuts (plain `rectangularHole` calls) WERE
+compensated, so drawn interference silently drifted from as-cut
+interference as BURN changed from its calibrated starting value. The one
+exception, by explicit project rule, is `calibration.py`'s kerf-test
+square, which must stay burn-neutral — it measures the real kerf, it
+doesn't compensate for it. **If BURN changes after calibration, the
+retention coupon (below) must be re-cut too**, for the same reason the
+kerf coupon itself must be — see README's cut-day flow.
 
 ### A. Side-wall lid detent
 
+Kinematics unchanged from iteration 2 (this mechanism's cam action was
+always sound — it's an X-Z part); only the strain (below) was refit.
+
 - Cut into EACH side wall, just below the lid slot floor (Z = 118.025): a
-  cantilever beam running parallel to X, Z-span 115.525 → 118.025 (2.5mm
-  wide), with a clearance cavity below it (Z 113.025 → 115.525) and a 1.0mm
-  severing slot at its free (tip) end — see `faxbox.detent.release_cut_rects`.
-  The root end (deeper into the wall) is left solid.
-- Beam spans box X 11.0 → 29.0 (`LID_DETENT_TIP_X` → `LID_DETENT_ROOT_X`,
-  18mm, centered on `LID_DETENT_X` = 20.0) — clear of the front-edge finger
-  joints (a vertical edge feature, unrelated to this X range) and ≥40mm from
-  the divider hole line (79.375–82.55).
+  cantilever beam running parallel to X, 2.5mm wide, with a clearance
+  cavity below it and a 1.0mm severing slot at its free (tip) end — see
+  `faxbox.detent.release_cut_rects`. The root end (deeper into the wall) is
+  left solid.
+- **Nub at the beam's free end (FIX2, red-team)**: iteration 2 put the nub
+  MID-BEAM at X=20 with the beam spanning 11→29 — the nub's own ramp meant
+  the actual strain-bearing span (root to nub, 29−20=9mm) was barely half
+  the drawn beam length, giving ε ≈ 6.9% at the root — well above
+  plywood's ~1.5–2% crack threshold (SpringFit, UIST 2019). The nub
+  position (`LID_DETENT_X` = 20.0, unchanged — the lid notch position is
+  unaffected) now sits `DETENT_SEVER_CLEARANCE` + half the nub's own base
+  width outward of the release cut's tip (`LID_DETENT_TIP_X` ≈ 14.65),
+  clear enough that the sever cut can't undercut the nub's own base, and
+  `LID_DETENT_ROOT_X` = `LID_DETENT_X` + `LID_DETENT_NUB_TO_ROOT_SPAN`
+  (22.0) = 42.0 — nearly the full beam length now bears load.
+  **ε = 3·w·δ/(2·L²)** with w = `DETENT_BEAM_WIDTH` (2.5), δ =
+  `LID_DETENT_ENGAGE` (1.5), L = 22.0 (root-to-nub span) → **ε ≈ 1.16%**,
+  a real margin below the crack threshold.
 - The nub is a ramped bump built into the lid-slot hole's own bottom
-  boundary (`faxbox.detent.lid_slot_with_nub_points`), centered at
-  `LID_DETENT_X`, rising from the slot floor (118.025) to `LID_DETENT_NUB_TOP_Z`
-  = 119.525 (1.5mm rise — exceeds the 0.8mm lid vertical play so the nub
-  stays engaged when the box tips and the lid shifts within its play). Top
-  clears the 122.0 slot ceiling by 2.475mm. Ramped on both X-faces at 30°,
-  with a 2.5mm flat top (a flat land rather than a knife edge, since a bare
-  wedge would concentrate stress in cross-grain plywood — see the Grain
-  caveat below); base width ≈7.7mm (`LID_DETENT_NUB_BASE_WIDTH`).
+  boundary (`faxbox.detent.lid_slot_with_nub_points`), rising from the slot
+  floor (118.025) to `LID_DETENT_NUB_TOP_Z` = 119.525 (1.5mm rise —
+  exceeds the 0.8mm lid vertical play so the nub stays engaged when the box
+  tips and the lid shifts within its play). Top clears the 122.0 slot
+  ceiling by 2.475mm. Ramped on both X-faces at 30°, with a 2.5mm flat top;
+  base width ≈7.7mm (`LID_DETENT_NUB_BASE_WIDTH`).
 - **Mating notch in the lid's side edges** (both long edges, one per wall):
   an edge-open recess (`faxbox.detent.notch_points`) at lid-local X =
   `LID_NOTCH_X` = 19.625 (= `LID_DETENT_X` − `LID_CLOSED_FRONT_X`, where
   `LID_CLOSED_FRONT_X` = 0.375 is the closed lid's front-edge offset from
-  the box's front face — DESIGN.md #8). Width ≈8.7mm (nub base + 1mm), depth
-  3.0mm (exceeds the lid's 2.425mm slot engagement with margin), mouth
-  corners eased by a 1.0mm chamfer. When closed, the nub pops up through the
-  notch: positive retention at a 90° front-down tip.
-- Both walls are mirror images (per the existing convention: drawn
-  exterior-face-up, left wall mirrored in local X) — the nub, release cut,
-  and lid-slot-with-nub polygon are all mirrored the same way the plain slot
-  already was, landing both walls' nubs at the same real box X.
+  the box's front face — DESIGN.md #8). Width ≈8.7mm (nub base + 1mm),
+  depth `LID_NOTCH_DEPTH` = **3.5mm** (bumped from 3.0mm — FIX3: once the
+  notch is drawn burn-shrunk so its AS-CUT depth matches nominal instead of
+  drifting with BURN, 3.0 left only ~0.075mm of real margin over the
+  lid-slot-engagement + 0.5mm requirement — less than BURN itself could
+  erase; 3.5 restores a real margin), mouth corners eased by a 1.0mm
+  chamfer. When closed, the nub pops up through the notch: positive
+  retention at a 90° front-down tip.
+- Both walls are mirror images (drawn exterior-face-up, left wall mirrored
+  in local X) — the nub, release cut, and lid-slot-with-nub polygon are all
+  mirrored the same way the plain slot already was, landing both walls'
+  nubs at the same real box X.
 
-### B. Drawer faceplate detent
+### B. Drawer side-wall flexure (replaces iteration 2's faceplate detent)
 
-- Cut into EACH faceplate, near BOTH Y side edges: a vertical cantilever
-  (along Z), 18mm long, Z-span 17.75 → 35.75 (`DRAWER_DETENT_ROOT_Z` →
-  `DRAWER_DETENT_TIP_Z`, centered on `DRAWER_DETENT_Z` = 26.75, the
-  faceplate's mid-height), 2.5mm wide in the flex direction, with the same
-  clearance-cavity + severing-slot release cut as mechanism A (transposed:
-  "along" is Z, "across" is the faceplate's drawn-x).
-- The nub protrudes `DRAWER_DETENT_PROTRUDE` = 1.2mm beyond the faceplate's
-  nominal edge (0.45mm interference past the 0.75mm `FACEPLATE_REVEAL` when
-  centered in its opening), ramped at 30° on both Y-faces with a 2.5mm flat
-  top, base width ≈6.66mm (`DRAWER_DETENT_NUB_BASE_WIDTH`).
-- Because this nub protrudes past the faceplate's own outer edge (there is
-  no pre-existing void to poke into, unlike mechanism A's lid slot), the
-  faceplate's outer boundary is hand-drawn (`faxbox.detent.edge_nub_detour`)
-  instead of Boxes.py's automatic straight "e" edges, which can't express a
-  local protrusion. This makes the faceplate's true drawn/measured footprint
-  `FACEPLATE_DRAWN_WIDTH` = 150.9 + 2×1.2 = 153.3mm rather than the plain
-  150.9mm nominal — **flagged deviation**: this legitimately changed
-  `tests/test_svg_geometry.py::test_faceplate_blank_size`'s measured
-  quantity (see that test's comment) and, since the faceplate no longer
-  calls `rectangularWall(..., "eeee", ...)` at all,
-  `test_edge_polarity_literals_present`'s literal count. Both were the
-  minimal, unavoidable, documented consequence of adding a REAL protruding
-  interference feature — there is no way to add retention here without the
-  physical part becoming physically bigger at the nub, and svg_utils's
-  bbox-based piece detection can't distinguish that from "a bigger nominal
-  blank" for the same connected outer path.
-- Grip slot (Y-centered, ~60mm from either edge) and the nub (near each Y
-  edge, Z-centered at mid-height) never intersect — their Y ranges are
-  disjoint regardless of Z overlap.
-- Snaps past the rear-wall opening's side edge on close (the opening's
-  interior corner, 3.175mm deep per DESIGN.md #4); the grip-slot pull cams
-  it back through on deliberate removal.
+- Cut into EACH of the drawer's two SIDE panels (Left Side, Right Side —
+  both, per drawer; the two drawers are identical so this applies to both
+  physical drawers), near the FRONT (faceplate) end: a cantilever beam
+  running parallel to X (the drawer's travel axis), 2.5mm wide, with a
+  clearance cavity above it (into the panel's solid material) and a 1.0mm
+  severing slot at its free (tip) end. The nub protrudes DOWN below the
+  panel's own bottom edge.
+- **Assembly convention (new, this project's own choice)**: since both ends
+  of a drawer side panel finger-joint identically to the Front and Back
+  panels (nothing else distinguishes them), this design defines
+  drawer-local x=0 as the end assembled against the **Front** panel (the
+  faceplate end). Both side panels must be installed with their flexure end
+  toward Front, not Back — flagged here since pre-iteration-3 parts had no
+  such constraint (either end was interchangeable).
+- **Nub depth**: `DRAWER_DETENT_ENGAGE` = **2.2mm**, defined as protrusion
+  below the drawer's TRUE exterior bottom (where the neighboring finger
+  tabs reach) — this must exceed the drawer's own 1.5mm opening vertical
+  clearance (`OPENING_HEIGHT` − `DRAWER_BODY["height"]`) by a real margin so
+  the nub stays engaged even when the drawer is lifted to the top of that
+  clearance band; 2.2 − 1.5 = **0.7mm** headroom. Drawn depth from the
+  panel's own local y=0 (the flexure zone's un-tabbed baseline, which sits
+  shallower than the tab reach by T since there's no tab there at all) is
+  `T + DRAWER_DETENT_ENGAGE` ≈ 5.375mm.
+- **Beam sizing by strain**: ε = 3·w·δ/(2·L²), w = `DETENT_BEAM_WIDTH`
+  (2.5), δ = `DRAWER_DETENT_ENGAGE` (2.2). Solving ε ≤ 1.5% for L gives
+  L ≥ ~23.45mm; `DRAWER_DETENT_NUB_TO_ROOT_SPAN` = **26.0mm** gives
+  **ε ≈ 1.22%**, a real margin below the crack threshold. Nub position
+  `DRAWER_DETENT_NUB_X` = 24.0 (drawer-local X, front end), release-cut tip
+  `DRAWER_DETENT_TIP_X` ≈ 17.44 (nub half-base + `DETENT_SEVER_CLEARANCE`
+  outward of the nub, same anti-bridging margin as mechanism A), root
+  `DRAWER_DETENT_ROOT_X` = 50.0 — the sever cut sits ≥15mm clear of the
+  front finger joints (17.44mm measured).
+- **Bottom-edge construction**: the side panel's bottom edge is normally
+  fully finger-jointed to the drawer's own Bottom panel along its whole
+  length; a Boxes.py finger-joint edge can't locally express the nub's
+  protrusion (the same limitation the removed faceplate detent hit), so a
+  short PLAIN zone (`DRAWER_DETENT_PLAIN_LO` ≈ 15.44 → `..._PLAIN_HI` =
+  52.0) replaces the finger joint there via a 3-segment CompoundEdge
+  (finger / purpose-built nub edge / finger — see
+  `generate_drawers.py`'s `_DrawerFlexureNubEdge`). The Bottom panel's own
+  matching finger-hole row is split to skip the same X-range, so there are
+  no unplugged holes.
+- **Kinematics**: on insertion, the drawer (faceplate trailing) has its nub
+  cam UP over the rear-wall opening's own sill web (the T=3.175mm-thick
+  rear-wall material below the bottom opening / above the top opening's
+  shelf-supported web — DESIGN.md #4) as it crosses the opening's own
+  X-span near the end of the insertion travel, then rides deflected along
+  the bay floor (bottom drawer) or shelf (top drawer) for the remaining
+  travel, dropping into a **catch hole** cut through that panel at the
+  closed position.
+- **Catch holes** (bottom panel for the bottom drawer, shelf for the top
+  drawer — 2 holes per panel, one per side wall):
+  - X position: `CATCH_HOLE_X` = `DRAWER_FRONT_INNER_FACE_CLOSED_X` −
+    `DRAWER_DETENT_NUB_X`, where `DRAWER_FRONT_INNER_FACE_CLOSED_X` =
+    `BAY_X1` − `DRAWER_BAY_GAP` (the 0.475mm closed-position reveal,
+    DESIGN.md #9) − T (faceplate/Front panel thickness) ≈ 297.975 — i.e.
+    derived from the rear wall plane, the closed-position reveal, and the
+    drawer body length, per the fix's own instruction, landing at
+    `CATCH_HOLE_X` ≈ 273.975 (≈24mm in from the rear wall's interior face —
+    matches the drawer's remaining travel after the nub clears the sill).
+  - X-length: `CATCH_HOLE_X_LENGTH` = nub base width + 0.8mm, keeping
+    engaged X-slop ≤ 0.8mm.
+  - Y-width: `CATCH_HOLE_Y_WIDTH` = T (side thickness) + 2×`DRAWER_LATERAL_GAP`
+    (the drawer's own ~4.9mm/side bay float) + 1mm margin ≈ 13.925mm, so the
+    nub can't miss the hole even at worst-case drawer skew.
+  - **Flagged tension**: sizing the hole to the FULL bay-wide lateral float
+    (as specified) puts its edge within ~0.5mm of the bottom panel's own
+    finger-jointed edge (the panel's usable Y-range near either bay wall is
+    inherently only ~4.9mm, since the drawer already fills all but ~9.75mm
+    of the interior width) — short of the general "≥3mm from any panel
+    edge" guidance elsewhere in this fix. The mandated Y-span requirement
+    (also this fix's own instruction, and the one the mutation-gate test
+    enforces) cannot be satisfied simultaneously with 3mm edge clearance
+    given the drawer's actual fit; the Y-span requirement was kept as
+    specified since narrowing it risks the nub missing the hole at
+    worst-case skew, which is the failure mode this hole exists to prevent.
+  - Visible from the box underside when the drawer is out (bottom panel
+    only) — cosmetic, accepted.
+- Grip slot (Y-centered) and the flexure zone (near each side panel's front
+  end) never intersect.
+
+### Nub-bridging note (why `DETENT_SEVER_CLEARANCE` exists)
+
+A nub whose ramped base straddles its own release/sever cut is NOT
+fully freed by that cut: the sever cut only removes material in the Z-band
+BELOW the nub's own base level (mechanism A) / X-band behind the flexure
+(mechanism B) — the nub's own ramped material, sitting ABOVE that band,
+remains a single connected shape that bridges from the fixed (outward)
+side to the free (beam) side right at its own base, regardless of the
+sever cut's position, UNLESS the sever cut sits entirely outward of the
+nub's own base footprint. This was verified empirically against the
+pre-fix wall geometry (whose nub-to-sever gap happened to be large enough,
+by construction of the old mid-beam nub position, to avoid the problem by
+accident) before being generalized into the explicit
+`DETENT_SEVER_CLEARANCE` constant both mechanisms now use.
 
 ### Grain caveat
 
@@ -355,25 +459,46 @@ Plywood cantilevers are ~3× weaker bending across the face-veneer grain than
 with it (SpringFit, UIST 2019). `layout.py`'s shelf packer never rotates
 parts — each piece keeps the same X/Y orientation from its source SVG onto
 the sheet — and this project assumes **grain runs along the sheet's long
-(X) axis** (already README's cut-day guidance: "Orient sheets with the face
-grain running along the sheet's long axis"). Under that assumption:
+(X) axis** (README's cut-day guidance: "Orient sheets with the face grain
+running along the sheet's long axis"). Under that assumption, checked
+against the ACTUAL `layout.py`/generator orientation (not assumed):
 
 - **Mechanism A (side wall)** is grain-favorable: the wall's long axis
   (298.45mm, local X) maps directly to the sheet's long axis with no
   rotation, and the beam's length (also along X) runs *with* the grain —
   the bending fibers at the beam's root are parallel to grain.
-- **Mechanism B (faceplate)** is grain-adverse: the faceplate's long axis
-  (150.9mm, local X = box Y) also maps to the sheet's long axis, but the
-  beam runs *perpendicular* to it (along Z) — the beam bends *across* grain,
-  the weaker direction.
+- **Mechanism B (drawer side wall)** is ALSO grain-favorable, unlike the
+  removed faceplate mechanism it replaces: the drawer side panel's long
+  axis (`BODY_INTERIOR_LENGTH` ≈ 212mm, local X, verified against the
+  generated `drawer.svg` — the "Left Side"/"Right Side" pieces measure
+  ~218.8mm wide × ~53–56mm tall, i.e. drawn WIDE, matching the sheet's long
+  axis with no rotation) maps to the sheet's long axis the same way, and
+  the beam (also along X) again runs *with* the grain. This is a genuine
+  improvement over the removed mechanism (whose faceplate-mounted beam ran
+  along Z, across grain, the weaker direction).
 
 This is exactly why the retention coupon (`faxbox.calibration.RetentionCoupon`,
-`output/retention_coupon.svg`) exists: cut both flexure samples on real stock
-oriented the same way the real parts will be, and confirm the faceplate
-sample's snap force is still adequate (not brittle) before committing to
-DRAWER_DETENT_PROTRUDE = 1.2 on the real faceplates. If it proves too weak,
-the documented fallback is magnets (issue #20's "Ideas to evaluate") rather
+`output/retention_coupon.svg`) exists regardless: cut every flexure sample on
+real stock oriented the same way the real parts will be, and confirm the
+snap force is adequate (not brittle, not too stiff) before committing to
+the real parts. If either mechanism proves too weak in practice, or the
+coupon can't be tuned to a good snap, the documented fallback is **magnets**
+(6mm discs in through-holes, 0.3–0.5mm undersize press-fit + CA glue) rather
 than forcing a larger interference that risks a snapped-off nub.
+
+### Failure modes (honest, not hidden)
+
+- **Lid detent (mechanism A) snapped flexure**: a fractured tongue drops a
+  loose chunk of plywood into the lid's own slot channel — a jam risk.
+  Never force the lid if it resists sliding; remove it fully (slide back
+  out toward the front) and check the slot channel for debris before
+  reinserting, rather than pushing harder.
+- **Drawer flexure (mechanism B) fracture**: the affected drawer loses its
+  detent (no more positive "seated" feel) but keeps sliding freely — it's a
+  retention failure, not a jam, since the flexure zone sits below the
+  drawer's own floor/shelf, not in its direct travel path. Safe to keep
+  using the drawer; the fallback (magnets, above) is the recorded fix if it
+  matters.
 
 ## Known deltas from SPEC.md targets
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,83 +1,119 @@
 # HANDOFF — fax-machine-box
 
-Written 2026-07-07 by the session that rebuilt the geometry and ran the
-red-team. Everything is committed and pushed to `main` (clean tree, nothing
-local-only). You are the wrap-up agent.
+Updated 2026-07-07 on branch `iter2-retention` by the session that ran the
+issue #20 red-team (3 critics) against the retention feature and fixed
+their findings. Do not treat this file's timestamp as "nothing has changed
+since v1" — issue #20 (lid + drawer retention) is now DONE on this branch,
+including a full mechanism replacement. Read DESIGN.md's "Retention
+(iteration 3)" section before touching any retention geometry.
 
 ## TL;DR for the next agent
 
-The project is **cut-ready**: 21 parts nested on 3 sheets + a kerf coupon,
-164 tests green, geometry adversarially reviewed across 3 red-team passes.
-There is no unfinished code. Your job is wrap-up: sanity-check the final
-state, support Ben through cut day (see README's 8-step checklist), and —
-only if he asks — start iteration 2 (issue #20, retention). Read DESIGN.md
-before touching anything; run `.venv/bin/python -m pytest tests/ -q` before
-and after any change.
+The project is **cut-ready with retention included**: 21 parts nested on 3
+sheets + a kerf coupon + a 5-piece retention coupon, 189 tests green,
+geometry adversarially reviewed (shell/drawer/lid geometry across 3 earlier
+red-team passes on `main`, retention across a 4th red-team pass on this
+branch). There is no unfinished code and no open TODO. Your job is
+wrap-up: sanity-check the final state, support Ben through cut day (see
+README's checklist — kerf coupon, THEN retention coupon, THEN real
+sheets), and merge this branch when Ben says go. Run
+`.venv/bin/python -m pytest tests/ -q` before and after any change.
 
 ## What this project is
 
 A laser-cut plywood storage box for Ben's "Fax Machine" pen-and-paper game:
 12"×6.5"×5" envelope, front paper compartment with a sliding lid, rear bay
 with two stacked drawers with flush faceplates, "FAX MACHINE" pixel-font
-engraving. Python generators (Boxes.py) emit SVGs; a test harness parses the
-actual SVG geometry and gates correctness. The dimensions come from Ben's
-**fully functional cardboard prototype**, so contents-fit is already
-physically validated.
+engraving. Both the lid and the drawers have spring-detent retention
+(issue #20) so they don't slide out if the box tips. Python generators
+(Boxes.py) emit SVGs; a test harness parses the actual SVG geometry and
+gates correctness. The dimensions come from Ben's **fully functional
+cardboard prototype**, so contents-fit is already physically validated.
 
 ## Current state — honest ledger
 
 **Done and verified:**
-- Issues #13–#19 all closed with evidence comments (GitHub).
-- Full suite: **164 passed, 0 failed, 0 xfail** (`.venv/bin/python -m pytest
-  tests/ -q`, ~13s). The suite regenerates all SVGs first, so it always
-  tests current code.
-- Red-team (4 Opus critics, 3 passes) found and we fixed: an
-  assembly-impossible top-panel joint, red part labels that would have
-  engraved, hollow engraving, an impossible README assembly order, a
-  thickness-relative `play` unit bug, a self-defeating kerf-square, a
-  grip-slot ligament bug, drawer in-stop. Details: SESSION_LOG.md
-  (2026-07-07 entries) and the issue comments.
+- Issues #13–#19 all closed on `main` with evidence comments (GitHub).
+- Issue #20 (retention) done on this branch, INCLUDING a full red-team
+  pass that found the first drawer mechanism (a nub on the faceplate) was
+  geometrically impossible — a faceplate is a Y-Z plate, the drawer
+  travels along X (normal to that plate), so a laser-cut ramp there is
+  never swept by the drawer's own motion. That mechanism was removed
+  entirely (faceplate is back to its exact original blank) and replaced
+  with a cantilever flexure in each drawer SIDE wall (an X-Z part, so its
+  ramp genuinely cams). The lid mechanism's kinematics were always sound;
+  only its beam strain was refit (nub moved from mid-beam to the beam's
+  free end — see DESIGN.md).
+- Full suite: **189 passed, 0 failed, 0 xfail** (`.venv/bin/python -m
+  pytest tests/ -q`, ~17s). The suite regenerates all SVGs first, so it
+  always tests current code. `tests/conftest.py` now also forces this
+  checkout's own `src/` onto the regeneration subprocess's PYTHONPATH, so
+  running the suite from a git WORKTREE can't silently test a different
+  checkout's code.
+- Mutation-gate re-validated for `test_retention.py` (rewritten wholesale
+  this session): 10/10 targeted mutations (wrong engagement depths, an
+  inverted nub, a shifted notch, a broken mirror, a deleted release cut, a
+  deleted coupon, a squared-off ramp, a plain-rectangle drawer side, a
+  halved catch hole) each independently turn the suite red, then green
+  again on revert. Full table in the PR description.
+- Burn compensation (previously "burn-neutral by design" for all
+  hand-drawn retention shapes) is now applied consistently — see
+  `faxbox/detent.py`'s module docstring for the exact model; the kerf-test
+  square in `calibration.py` is the one deliberate exception (project
+  rule: it measures kerf, it must not compensate for it).
 - Bed size resolved: NYC Resistor runs an Epilog Fusion 32 60W, 32"×20"
-  bed; the scary "12×24" figure was a stale 2013 comment about their old
-  machine (sources in docs/service-comparison.md). All sheets fit.
+  bed; sources in docs/service-comparison.md. All sheets fit both that and
+  the conservative 24"×18" fallback `layout.py` still packs to.
 - Outputs (regenerate any time, they're gitignored): `output/sheet_1..3.svg`
-  (cut files), `output/kerf_coupon.svg` (cut FIRST on scrap),
-  `output/final_layout.svg` (reference only, too big for the bed).
+  (cut files, 21 parts total), `output/kerf_coupon.svg` (cut FIRST on
+  scrap), `output/retention_coupon.svg` (cut SECOND on scrap — 5 pieces:
+  Wall Flexure Sample, Lid Notch Strip, Drawer-Side Flexure Sample, Mock
+  Sill Edge, Mock Floor Strip), `output/final_layout.svg` (reference only,
+  too big for the bed).
 
 **Open / not done:**
-- Issue #20 (open, deferred by Ben): lid + drawer retention for the NEXT
-  iteration. Ben explicitly said ship v1 without it. Do not start unless he
-  asks.
-- Nothing has been physically cut. BURN=0.08 and FINGER_PLAY=0.1 are
-  UNCALIBRATED starting values — the coupon workflow in README step 3
-  exists precisely because of this.
+- Nothing has been physically cut. `BURN=0.08` and `FINGER_PLAY=0.1` are
+  still UNCALIBRATED starting values — the coupon workflow in README steps
+  3/3b exists precisely because of this, and now covers retention too
+  (tune `LID_DETENT_ENGAGE` / `DRAWER_DETENT_ENGAGE` against the retention
+  coupon after the kerf coupon, before cutting real parts).
+- This branch (`iter2-retention`) has NOT been merged to `main` — it's
+  pushed and PR #22 is open/updated, but merging is Ben's call, not
+  automatic.
 - The Fusion 32 bed size is medium-high confidence from web research; a
   five-second look at the machine on cut day is the final confirmation.
+- Magnets (6mm discs, press-fit + CA) are the recorded fallback if either
+  flexure proves too weak/brittle in practice or won't tune well on the
+  coupon — not implemented, just documented (DESIGN.md, README) so it
+  isn't rediscovered from scratch.
 
 ## Next concrete steps (in order)
 
-1. Fresh-eyes check: `git pull`, run the suite, regenerate outputs, open
-   the three sheet SVGs and eyeball them (piece labels are gray reference
-   text; blue=cut, red=engrave hatching on the right wall only).
-2. When Ben schedules the cut: walk him through README "Cut day at NYC
-   Resistor" steps 1–8 in order. The coupon-first calibration (step 3) is
-   the one thing that must not be skipped. If measured kerf ≠ 0.08:
-   `BURN = (measured_square − 10.0)/2` in config.py, regenerate everything
-   including the coupon, re-cut coupon, then cut sheets.
-3. Consider exporting sheets to PDF before cut day — NYC Resistor's wiki
-   warns their CorelDraw X5 import can mangle some SVGs (sheets are
-   Inkscape-namespace-free, but PDF is the belt-and-suspenders).
+1. Fresh-eyes check: `git pull` (this branch), run the suite, regenerate
+   outputs, render the changed parts (walls, lid, drawer sides, bottom
+   panel, shelf, coupon) and eyeball the retention features specifically —
+   nub ramps, catch holes, the lid notch — since this is new geometry a
+   quick visual pass is worth the five minutes.
+2. Get Ben's go to merge `iter2-retention` into `main` (or continue
+   iterating per his feedback on PR #22).
+3. When Ben schedules the cut: walk him through README's cut-day
+   checklist in order — kerf coupon (step 3) THEN retention coupon (step
+   3b) THEN real sheets. Both coupon steps must not be skipped; the
+   retention coupon in particular is the only real-world validation this
+   project has for the drawer side-wall mechanism, which has never been
+   physically cut. **Grain orientation is a hard gate** (README step 2) —
+   both flexures depend on it.
 4. After the physical cut: capture lessons into LEARNINGS.md and the
-   calibrated BURN/FINGER_PLAY values into config.py with a comment.
-5. Iteration 2 = issue #20, only on Ben's go.
+   calibrated `BURN`/`FINGER_PLAY`/`LID_DETENT_ENGAGE`/
+   `DRAWER_DETENT_ENGAGE` values into config.py with a comment.
 
 ## Build/test baseline
 
-`.venv/bin/python -m pytest tests/ -q` → `164 passed in ~13s` at commit
-`1302903` (verify current HEAD matches or is ahead). venv already exists;
-if rebuilding: `python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"`
-(Boxes.py comes from GitHub — needs network; PyPI "boxes" is the wrong
-package).
+`.venv/bin/python -m pytest tests/ -q` → `189 passed in ~17s` on branch
+`iter2-retention` (verify current HEAD matches or is ahead). venv already
+exists; if rebuilding: `python3 -m venv .venv && .venv/bin/pip install -e
+".[dev]"` (Boxes.py comes from GitHub — needs network; PyPI "boxes" is the
+wrong package).
 
 ## Decisions made (locked — do not relitigate)
 
@@ -87,10 +123,20 @@ package).
   uniform 3.175mm ply.
 - Lid slot vertical clearance is 0.8mm, a documented deviation from SPEC's
   1.5mm (DESIGN.md explains why; README discloses it).
-- No retention in v1 (Ben, this session): lid/drawers slide out when
-  tipped; documented in README "Know before you build".
-- Faceplates sit recessed 0.475mm when closed (the slide gap) — "near
-  flush" is correct behavior, not a bug.
+- Retention (issue #20, this branch): both the lid and the drawers have
+  spring-detent retention, not a hard lock — documented in README "Know
+  before you build". The drawer mechanism lives in the SIDE panels, not
+  the faceplate (locked after the red-team finding above — do not move it
+  back to the faceplate).
+- Faceplates are the exact original v1 blank again (150.9 × 53.5, plain
+  edges) — no retention feature of their own. Recessed 0.475mm when closed
+  (the slide gap) — "near flush" is correct behavior, not a bug.
+- `DETENT_SEVER_CLEARANCE` (1.5mm, both mechanisms): the gap kept between
+  a nub's own ramped base and its release/sever cut, so the sever cut
+  can't undercut the nub's base and leave it bridged to the fixed material
+  outward of it. Verified against the actual drawn geometry before being
+  generalized into a named constant — don't let a future edit shrink this
+  toward zero without re-checking that bridging concern.
 
 ## Hard constraints
 
@@ -98,34 +144,42 @@ package).
   tests enforce it. Change DESIGN.md first or not at all.
 - **Never weaken a test to make it pass** (Ben's standing rule, enforced
   since issue #7). The red-team specifically hardened the suite with
-  positional/mating assertions that catch demonstrated green-but-broken
-  mutations — treat any urge to loosen a tolerance as a design smell.
+  positional/mating assertions and a mutation-gate exercise — treat any
+  urge to loosen a tolerance as a design smell.
 - Boxes.py `FingerJoint play` is RELATIVE to thickness — generators must
   pass `FINGER_PLAY_RELATIVE`, never the raw mm value.
-- The kerf square in calibration.py must stay burn-neutral (raw ctx path).
+- The kerf square in calibration.py must stay burn-neutral (raw ctx path)
+  — the ONE deliberate exception to "all retention geometry is now
+  burn-compensated."
 
 ## Gotchas (full list in LEARNINGS.md — read it)
 
 Highlights: 'f' and 'F' edges BOTH protrude one thickness (flush panel
 joints need `fingerHolesAt` hole lines, not edge joints); a fingered edge
-segment must equal its mating hole-row length exactly (CompoundEdge trick);
-`--reference 0` required or Boxes.py draws a black calibration rectangle;
-ctx.fill() unimplemented (engraving = hatched strokes); piece detection is
+segment must equal its mating hole-row length exactly (CompoundEdge trick —
+now also used for the drawer side wall's flexure zone, via a purpose-built
+Edge subclass standing in for one CompoundEdge segment); `--reference 0`
+required or Boxes.py draws a black calibration rectangle; ctx.fill()
+unimplemented (engraving = hatched strokes); piece detection is
 bbox-containment clustering with 0.2mm tolerance (tests/svg_utils.py);
 `<text>` fill colors are live laser instructions (labels are gray for a
-reason). Ben's terminal can't copy-paste — never hand him commands to paste;
-run them yourself or write files.
+reason); a nub whose ramped base straddles its own sever cut is NOT fully
+freed by it (see `DETENT_SEVER_CLEARANCE` above) — this bit the initial
+implementation of the drawer flexure before the coupon math was checked
+against the actual drawn geometry. Ben's terminal can't copy-paste — never
+hand him commands to paste; run them yourself or write files.
 
 ## Where everything lives
 
 - Repo: `Gilbetrar/fax-machine-box` (GitHub), local `~/AI/Projects/
-  fax-machine-box`, branch `main`, all pushed.
+  fax-machine-box`, branch `iter2-retention` (this work), PR #22.
 - Geometry spec: `DESIGN.md`. Dimensions: `src/faxbox/config.py`.
 - Generators: `src/faxbox/{shell_generator,generate_drawers,generate_lids,
-  layout,calibration}.py`.
+  layout,calibration}.py`. Shared retention geometry helpers:
+  `src/faxbox/detent.py`.
 - Tests: `tests/` (svg_utils.py = parsing helpers; assembly-fit = config
-  math; svg_geometry = real-SVG positional checks; layout; laser
-  requirements).
+  math; svg_geometry = real-SVG positional checks; retention = retention
+  mechanism checks, rewritten this session; layout; laser requirements).
 - History/rationale: `SESSION_LOG.md` (chronological), `LEARNINGS.md`
   (distilled), GitHub issues #12–#20 (decision record in comments).
 - Cut-day instructions: `README.md` bottom half.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,23 +1,64 @@
 # HANDOFF — fax-machine-box
 
-Updated 2026-07-07 on branch `iter2-retention` by the session that ran the
-issue #20 red-team (3 critics) against the retention feature and fixed
-their findings. Do not treat this file's timestamp as "nothing has changed
-since v1" — issue #20 (lid + drawer retention) is now DONE on this branch,
-including a full mechanism replacement. Read DESIGN.md's "Retention
-(iteration 3)" section before touching any retention geometry.
+Updated 2026-07-07 on branch `iter2-retention` by the session that ran a
+THIRD retention red-team pass (pass-3) and fixed its findings on top of the
+earlier pass-2 fixes. Do not treat this file's timestamp as "nothing has
+changed since v1" — issue #20 (lid + drawer retention) is now DONE on this
+branch, including a full mechanism replacement AND a pass-3 fix round (see
+below). Read DESIGN.md's "Retention (iteration 3)" section before touching
+any retention geometry.
 
 ## TL;DR for the next agent
 
 The project is **cut-ready with retention included**: 21 parts nested on 3
-sheets + a kerf coupon + a 5-piece retention coupon, 189 tests green,
+sheets + a kerf coupon + a 5-piece retention coupon, 192 tests green,
 geometry adversarially reviewed (shell/drawer/lid geometry across 3 earlier
-red-team passes on `main`, retention across a 4th red-team pass on this
-branch). There is no unfinished code and no open TODO. Your job is
-wrap-up: sanity-check the final state, support Ben through cut day (see
-README's checklist — kerf coupon, THEN retention coupon, THEN real
+red-team passes on `main`, retention across a pass-2 AND pass-3 red-team
+pass on this branch). There is no unfinished code and no open TODO. Your
+job is wrap-up: sanity-check the final state, support Ben through cut day
+(see README's checklist — kerf coupon, THEN retention coupon, THEN real
 sheets), and merge this branch when Ben says go. Run
-`.venv/bin/python -m pytest tests/ -q` before and after any change.
+`.venv/bin/python -m pytest tests/ -q` before and after any change (no
+shell-level `PYTHONPATH` override needed — `tests/conftest.py` now puts
+this checkout's own `src/` at the front of `sys.path` at import time, so
+even a git-worktree checkout tests its OWN code in-process, not just in
+regeneration subprocesses — see pass-3 F1 below).
+
+## Pass-3 red-team fixes (this session, on top of pass-2)
+
+A pass-2 critic caught four more findings; all four are now fixed, with
+tests proving each catches its own regression (mutate -> red -> revert ->
+green):
+
+- **F1 (CRITICAL)**: `tests/conftest.py`'s `os.environ["PYTHONPATH"]`
+  assignment only affected subprocesses, not pytest's own in-process
+  imports — a worktree checkout's test run could silently exercise a
+  DIFFERENT checkout's `faxbox` code. Fixed with `sys.path.insert(0, ...)`
+  at conftest import time (before any `faxbox` import in the session).
+- **F2 (CRITICAL)**: the drawer's own Bottom panel is a solid sheet
+  directly under the flexure nub's swept path — no clearance opening
+  existed there before this fix, so the nub had nowhere to go. Fixed with
+  a rectangular clearance slot per side wall through `generate_drawers.py`'s
+  Bottom panel (`DRAWER_BOTTOM_SLOT_X_LENGTH` / `..._Y_SPAN` in config.py).
+- **F3 (MAJOR)**: the drawer flexure's free tip rises MORE than its own
+  designed nub engagement (it overhangs past the nub's load point), so the
+  shared `DETENT_CLEARANCE` (2.5mm) cavity was too shallow for the drawer
+  mechanism specifically — it would bind at ~1.85mm, short of the designed
+  2.2mm engagement. Fixed with a `config._tip_rise` formula and per-
+  mechanism cavities (`LID_DETENT_CAVITY` ≈2.5, unchanged;
+  `DRAWER_DETENT_CAVITY` ≈3.47, deeper).
+  - Verified: cavity has room within the drawer side's 53.5mm height, no
+    web thinner than `MIN_WEB` (3.0mm) introduced.
+- **F4 (MAJOR)**: catch-hole↔nub registration was untested end-to-end (a
+  `CATCH_HOLE_X += 5.0` mutation stayed green), and
+  `DRAWER_DETENT_NUB_BASE_WIDTH` was misnamed (its value is the nub's width
+  at the FLOOR plane, not its actual widest "base"). Fixed with a new
+  independent-datum registration test
+  (`test_catch_hole_registers_with_nub_via_independent_datums`) and a
+  rename/split into `NUB_WIDTH_AT_FLOOR_PLANE` / `NUB_WIDTH_AT_WALL_PLANE`.
+
+See DESIGN.md's "Retention (iteration 3)" section for the full derivation
+of each fix.
 
 ## What this project is
 
@@ -44,18 +85,26 @@ cardboard prototype**, so contents-fit is already physically validated.
   ramp genuinely cams). The lid mechanism's kinematics were always sound;
   only its beam strain was refit (nub moved from mid-beam to the beam's
   free end — see DESIGN.md).
-- Full suite: **189 passed, 0 failed, 0 xfail** (`.venv/bin/python -m
-  pytest tests/ -q`, ~17s). The suite regenerates all SVGs first, so it
-  always tests current code. `tests/conftest.py` now also forces this
-  checkout's own `src/` onto the regeneration subprocess's PYTHONPATH, so
-  running the suite from a git WORKTREE can't silently test a different
-  checkout's code.
+- Full suite: **192 passed, 0 failed, 0 xfail** (`.venv/bin/python -m
+  pytest tests/ -q`, ~17s — no shell-level `PYTHONPATH` override needed).
+  The suite regenerates all SVGs first, so it always tests current code.
+  `tests/conftest.py` forces this checkout's own `src/` onto BOTH the
+  regeneration subprocess's PYTHONPATH AND the front of pytest's own
+  in-process `sys.path` (pass-3 F1 — the env-var-only version could
+  silently test a different checkout's code from a git WORKTREE, since it
+  only affected subprocesses, not pytest's own already-resolved imports).
 - Mutation-gate re-validated for `test_retention.py` (rewritten wholesale
-  this session): 10/10 targeted mutations (wrong engagement depths, an
+  in the pass-2 session): 10/10 targeted mutations (wrong engagement depths, an
   inverted nub, a shifted notch, a broken mirror, a deleted release cut, a
   deleted coupon, a squared-off ramp, a plain-rectangle drawer side, a
   halved catch hole) each independently turn the suite red, then green
   again on revert. Full table in the PR description.
+- Pass-3 mutation-gate (this session, all verified red -> green on
+  revert): removing the F2 bottom-panel clearance slot, `CATCH_HOLE_X +=
+  5.0`, and reverting `DRAWER_DETENT_CAVITY` to the old shared 2.5mm value
+  (this last one required adding a new test — nothing previously caught
+  it, since the strain test only checks bending stress, not cavity depth).
+  See the PR #22 comment for the pass-3 summary.
 - Burn compensation (previously "burn-neutral by design" for all
   hand-drawn retention shapes) is now applied consistently — see
   `faxbox/detent.py`'s module docstring for the exact model; the kerf-test
@@ -109,7 +158,7 @@ cardboard prototype**, so contents-fit is already physically validated.
 
 ## Build/test baseline
 
-`.venv/bin/python -m pytest tests/ -q` → `189 passed in ~17s` on branch
+`.venv/bin/python -m pytest tests/ -q` → `192 passed in ~17s` on branch
 `iter2-retention` (verify current HEAD matches or is ahead). venv already
 exists; if rebuilding: `python3 -m venv .venv && .venv/bin/pip install -e
 ".[dev]"` (Boxes.py comes from GitHub — needs network; PyPI "boxes" is the

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Generate every part, then nest them onto cut-ready sheets:
 .venv/bin/python -m faxbox.generate_drawers   # one drawer's 6 pieces -> output/drawer.svg (cut TWICE)
 .venv/bin/python -m faxbox.generate_lids      # sliding lid: 1 piece -> output/lids.svg
 .venv/bin/python -m faxbox.layout             # nests all of the above onto output/sheet_1.svg, sheet_2.svg, ...
-.venv/bin/python -m faxbox.calibration        # kerf/thickness test coupon -> output/kerf_coupon.svg (cut on scrap FIRST, see "Cut-day checklist")
+.venv/bin/python -m faxbox.calibration        # kerf/thickness coupon -> output/kerf_coupon.svg,
+                                               # AND retention-tuning coupon -> output/retention_coupon.svg
+                                               # (cut both on scrap FIRST, see "Cut-day checklist")
 ```
 
 `layout.py` also writes `output/final_layout.svg` — a combined, true-scale
@@ -58,7 +60,8 @@ fax-machine-box/
 │   ├── generate_drawers.py  # one drawer's 6 pieces (body x5 + faceplate); cut this sheet twice
 │   ├── generate_lids.py     # sliding lid (1 piece)
 │   ├── layout.py            # nests all parts onto bed-sized sheets for cutting
-│   └── calibration.py       # kerf/ply-thickness test coupon -> output/kerf_coupon.svg
+│   └── calibration.py       # kerf/ply-thickness coupon -> kerf_coupon.svg, AND
+│                            # the retention-tuning coupon -> retention_coupon.svg
 ├── tests/                   # pytest harness: geometry, laser-compliance, and layout checks
 ├── docs/service-comparison.md  # laser service comparison + verified NYC Resistor constraints
 ├── DESIGN.md                # canonical geometry — the source of truth for every number
@@ -128,9 +131,10 @@ removable cover.
 - [ ] 1× Kerf/thickness coupon — three ply-thickness gauge slots (3.05 /
   3.175 / 3.30mm) and a 10mm reference square. Cut this on scrap *before*
   cutting any real part; see "Cut-day checklist" step 3.
-- [ ] 4× Retention coupon pieces (issue #20) — Wall Flexure Sample, Lid
-  Notch Strip, Faceplate Flexure Sample, Mock Opening Edge. Cut on scrap
-  *before* the real iteration-2 parts; see "Cut-day checklist" step 3b.
+- [ ] 5× Retention coupon pieces (issue #20, iteration 3) — Wall Flexure
+  Sample, Lid Notch Strip, Drawer-Side Flexure Sample, Mock Sill Edge, Mock
+  Floor Strip. Cut on scrap *before* the real iteration-3 parts; see
+  "Cut-day checklist" step 3b.
 
 ## Wall identification (read this before assembly)
 
@@ -263,19 +267,36 @@ This design accepts some real tradeoffs to hit the SPEC envelope and the
 front-insert lid concept. None of these are bugs — they're documented so
 nobody "fixes" them mid-build or is surprised later:
 
-- **The sliding lid has spring-detent retention (iteration 2, issue #20),
-  not a lock.** Each side wall carries a cantilever nub that pops through a
-  matching notch in the lid's side edges when it's closed, holding it
-  seated if the box tips 90° front-down. It's still a light detent, not a
-  latch — don't rely on it against a hard drop, and it still slides free
-  with normal one-finger effort when you want it to. See DESIGN.md
-  "Retention (iteration 2)" for the mechanism; **tune the fit on the
-  retention coupon before cutting real parts** (see the checklist below).
-- **The drawers have the same kind of detent, not a hard stop.** Each
-  faceplate carries a cantilever nub per side that snaps behind the
-  rear-wall opening's edge on close, holding the drawer seated if the box
-  tips 90° rear-down. Same caveat: a detent, not a latch — pull with the
-  grip slot as usual to open.
+- **The sliding lid has spring-detent retention (issue #20), not a lock.**
+  Each side wall carries a cantilever nub that pops through a matching
+  notch in the lid's side edges when it's closed, holding it seated if the
+  box tips 90° front-down. It's still a light detent, not a latch — don't
+  rely on it against a hard drop, and it still slides free with normal
+  one-finger effort when you want it to. See DESIGN.md "Retention
+  (iteration 3)" for the mechanism; **tune the fit on the retention coupon
+  before cutting real parts** (see the checklist below). If a fractured
+  flexure ever drops a loose chunk into the lid's slot channel, **never
+  force the lid** — remove it fully and check the channel for debris first.
+- **The drawers have the same kind of detent, not a hard stop — and it
+  lives in the SIDE panels, not the faceplate.** Each drawer side wall
+  (Left Side, Right Side) carries a cantilever nub near its front
+  (faceplate) end that snaps into a catch hole in the bottom panel/shelf on
+  close, holding the drawer seated. (An earlier revision tried this on the
+  faceplate instead; red-team review found that geometrically impossible —
+  a faceplate is a Y-Z plate and can't cam against the drawer's X-axis
+  travel — so it was moved to the side walls, an X-Z part, before any real
+  part was cut.) Same caveat as the lid: a detent, not a latch — pull with
+  the grip slot as usual to open. If a flexure ever fractures, the drawer
+  simply loses its "seated" feel but keeps sliding freely (not a jam).
+  **Both drawer side panels must be installed with their flexure end
+  (near one end of the panel) toward the Front panel, not the Back** — see
+  DESIGN.md "Retention" for which end that is; getting it backwards means
+  the nub ends up near the divider instead of the rear-wall opening.
+- **Recorded fallback if either flexure proves too weak or won't tune
+  well on the coupon: magnets.** 6mm discs in through-holes, 0.3–0.5mm
+  undersize press-fit + CA glue, in place of the cut flexure/nub. Not
+  implemented in this design — noted here and in DESIGN.md so it isn't
+  rediscovered from scratch if the plywood proves too brittle in practice.
 - **Drawers close flush by bottoming out on the divider, not the rear
   wall.** The inset faceplate never bears against the rear-wall opening
   frame — the drawer body's front face is what stops against the divider
@@ -306,20 +327,31 @@ this checklist is current.
    current machine is an **Epilog Fusion 32 60W — 32"×20" (812×508mm) work
    area**, confirmed by their wiki (edited 2026), 2025–26 class listings,
    and Epilog's spec sheet for that exact model (sources in
-   docs/service-comparison.md). This project's three sheets measure
-   ~**21.8"×14.0"**, **21.6"×17.1"**, and **21.6"×9.8"** — all fit with
-   room to spare. A five-second look at the machine confirms it (the
-   Fusion 32 bed is visibly ~2.5ft wide). If it somehow isn't that machine,
-   re-nest: change `SHEET_WIDTH_MM` / `SHEET_HEIGHT_MM` in
-   `src/faxbox/layout.py`, rerun `.venv/bin/python -m faxbox.layout`, and
-   re-check the printed sheet dimensions.
+   docs/service-comparison.md). This project's three sheets currently
+   measure ~**21.8"×14.0"**, **22.8"×17.1"**, and **21.5"×10.0"**
+   (regenerate and read the real numbers with `.venv/bin/python -m
+   faxbox.layout` before cutting — these will drift slightly whenever
+   config.py's retention constants change) — all fit with room to spare. A
+   five-second look at the machine confirms it (the Fusion 32 bed is
+   visibly ~2.5ft wide). If it somehow isn't that machine, re-nest: change
+   `SHEET_WIDTH_MM` / `SHEET_HEIGHT_MM` in `src/faxbox/layout.py`, rerun
+   `.venv/bin/python -m faxbox.layout`, and re-check the printed sheet
+   dimensions.
 2. **Material.** Bring **Baltic Birch specifically**, not generic/cheap
    plywood — cheap ply's interior voids can blow out this design's thinnest
    features (the 3.175mm webs in the rear-wall drawer openings and the
    5.0mm cantilevered lid rail) when the laser hits a void instead of solid
    wood. Bring at least **three sheets, each at least 22"×15"**, plus extra
-   scrap for the kerf coupon (step 3). Orient sheets with the **face grain
-   running along the sheet's long axis** for stiffness on the long spans.
+   scrap for the kerf coupon (step 3).
+   - **HARD GATE: orient every sheet with the face grain running along the
+     sheet's long axis before cutting anything.** This isn't optional
+     styling guidance — both retention flexures (lid detent and drawer
+     side-wall detent, DESIGN.md "Retention") are cantilevers whose beam
+     runs along each part's long (X) axis; plywood bends ~3× weaker across
+     the grain than with it (SpringFit, UIST 2019), so cutting a sheet
+     rotated 90° from this turns a margin-checked 1.2% strain into a
+     cross-grain beam that can crack on the first snap. Check grain
+     direction on the actual sheet before it goes on the bed, not after.
 3. **Cut `output/kerf_coupon.svg` on scrap FIRST, before any real part.**
    It has three ply-thickness gauge slots (3.05 / 3.175 / 3.30mm) and a
    10mm reference square. Find which gauge slot *your actual sheet* fits
@@ -331,22 +363,41 @@ this checklist is current.
    confirm before trusting the gauge slots) before cutting real parts. Do not skip this
    because `BURN`/`FINGER_PLAY` already have values in the repo — those are
    starting values, not calibrated ones.
-3b. **Cut `output/retention_coupon.svg` on scrap NEXT, before the real
-   iteration-2 parts** (issue #20's spring-detent lid/drawer retention — see
-   DESIGN.md "Retention (iteration 2)"). Four small pieces: a Wall Flexure
-   Sample + Lid Notch Strip (press the notch over the sample's nub and feel
-   it snap in/out), and a Faceplate Flexure Sample + Mock Opening Edge
-   (slide the mock edge across the sample's nub the way a real close would).
-   Too loose (pops out with a light nudge) or too stiff (won't seat without
-   force, or feels like it might snap the nub off) — adjust
-   `LID_DETENT_ENGAGE` and/or `DRAWER_DETENT_PROTRUDE` in
-   `src/faxbox/config.py`, regenerate `calibration` (and everything else,
-   since those constants also drive the real wall/lid/faceplate geometry),
-   and re-cut before trusting the real parts' fit. Cut both flexure samples
-   with the same grain orientation the real parts will have (see DESIGN.md's
-   Grain caveat) — the faceplate sample bends across grain, the weaker
-   direction, so it's the one most likely to need tuning or a fallback to
-   magnets if the ply proves too brittle.
+3b. **Cut `output/retention_coupon.svg` on scrap NEXT (after the kerf
+   coupon, before the real iteration-3 parts)** — issue #20's spring-detent
+   lid/drawer retention, see DESIGN.md "Retention (iteration 3)". Five
+   small pieces:
+   - **Wall Flexure Sample + Lid Notch Strip**: press the strip's notch
+     over the sample's nub and feel it snap in/out.
+   - **Drawer-Side Flexure Sample + Mock Sill Edge + Mock Floor Strip**:
+     this one exercises the REAL travel axis, not just a press-fit — hold
+     the Mock Sill Edge across the sample near its nub end and slide the
+     sample under it (the nub cams up and over, same as a real insertion
+     crossing the rear-wall opening's own web), then keep sliding the
+     sample across the Mock Floor Strip until it reaches the strip's catch
+     hole and snaps down into it.
+
+   **Tuning rule (same spirit as the kerf coupon's own BURN formula, step
+   3 above)**: seated sample pops free when inverted and shaken → raise
+   the relevant ENGAGE value (`LID_DETENT_ENGAGE` or
+   `DRAWER_DETENT_ENGAGE`, in `src/faxbox/config.py`) by 0.25 and re-cut
+   that coupon; can't slide/seat with one-finger force → lower it by 0.25.
+   Iterate on scrap until BOTH mechanisms pass, THEN regenerate all real
+   sheets. This is the recorded validation for issue #20's force criteria.
+   Regenerate `calibration` (and everything else, since those constants
+   also drive the real wall/lid/drawer-side geometry) and re-cut before
+   trusting the real parts' fit.
+
+   **If you change `BURN` after this step (e.g. from the kerf coupon in
+   step 3), the retention coupon must be re-cut too** — every retention
+   nub/notch/catch-hole is now drawn BURN-compensated (DESIGN.md "Retention",
+   burn paragraph), so its as-cut size tracks `BURN` the same way the rest
+   of the box's finger joints do.
+
+   Cut every flexure sample with the same grain orientation the real parts
+   will have (see the hard gate in step 2, and DESIGN.md's Grain caveat) —
+   both mechanisms are grain-favorable under that orientation, but a
+   rotated sheet defeats that.
 4. **CorelDraw import.** NYC Resistor's workflow is CorelDraw-based; their
    tips page warns Inkscape's raw SVG export can get corrupted there and
    recommends exporting PDF instead. On import: set all strokes to

--- a/README.md
+++ b/README.md
@@ -122,11 +122,15 @@ There is **no separate flat/tabbed lid** — that part doesn't exist in this
 design. The drawer bay is covered by the fixed Top Panel above, not a
 removable cover.
 
-**Calibration — standalone, not part of the box (from `kerf_coupon.svg`):**
+**Calibration — standalone, not part of the box (from `kerf_coupon.svg` and
+`retention_coupon.svg`):**
 
 - [ ] 1× Kerf/thickness coupon — three ply-thickness gauge slots (3.05 /
   3.175 / 3.30mm) and a 10mm reference square. Cut this on scrap *before*
   cutting any real part; see "Cut-day checklist" step 3.
+- [ ] 4× Retention coupon pieces (issue #20) — Wall Flexure Sample, Lid
+  Notch Strip, Faceplate Flexure Sample, Mock Opening Edge. Cut on scrap
+  *before* the real iteration-2 parts; see "Cut-day checklist" step 3b.
 
 ## Wall identification (read this before assembly)
 
@@ -259,16 +263,19 @@ This design accepts some real tradeoffs to hit the SPEC envelope and the
 front-insert lid concept. None of these are bugs — they're documented so
 nobody "fixes" them mid-build or is surprised later:
 
-- **The sliding lid has no retention along its travel axis.** The divider
-  stops it from sliding in too far (rearward), but nothing stops it sliding
-  back *out* the front. Tip the box front-down and the lid will slide out.
-  This is an accepted cost of the front-insert design (the slots have to be
-  open at the front edge for the lid to go in at all) — **carry the box
-  level**, especially with the lid closed.
-- **The drawers have no out-stop either.** Nothing prevents a drawer from
-  sliding fully out its rear-wall opening. Tip the box rear-down and a
-  drawer will slide free. Don't rely on friction to keep drawers seated in
-  transit.
+- **The sliding lid has spring-detent retention (iteration 2, issue #20),
+  not a lock.** Each side wall carries a cantilever nub that pops through a
+  matching notch in the lid's side edges when it's closed, holding it
+  seated if the box tips 90° front-down. It's still a light detent, not a
+  latch — don't rely on it against a hard drop, and it still slides free
+  with normal one-finger effort when you want it to. See DESIGN.md
+  "Retention (iteration 2)" for the mechanism; **tune the fit on the
+  retention coupon before cutting real parts** (see the checklist below).
+- **The drawers have the same kind of detent, not a hard stop.** Each
+  faceplate carries a cantilever nub per side that snaps behind the
+  rear-wall opening's edge on close, holding the drawer seated if the box
+  tips 90° rear-down. Same caveat: a detent, not a latch — pull with the
+  grip slot as usual to open.
 - **Drawers close flush by bottoming out on the divider, not the rear
   wall.** The inset faceplate never bears against the rear-wall opening
   frame — the drawer body's front face is what stops against the divider
@@ -324,6 +331,22 @@ this checklist is current.
    confirm before trusting the gauge slots) before cutting real parts. Do not skip this
    because `BURN`/`FINGER_PLAY` already have values in the repo — those are
    starting values, not calibrated ones.
+3b. **Cut `output/retention_coupon.svg` on scrap NEXT, before the real
+   iteration-2 parts** (issue #20's spring-detent lid/drawer retention — see
+   DESIGN.md "Retention (iteration 2)"). Four small pieces: a Wall Flexure
+   Sample + Lid Notch Strip (press the notch over the sample's nub and feel
+   it snap in/out), and a Faceplate Flexure Sample + Mock Opening Edge
+   (slide the mock edge across the sample's nub the way a real close would).
+   Too loose (pops out with a light nudge) or too stiff (won't seat without
+   force, or feels like it might snap the nub off) — adjust
+   `LID_DETENT_ENGAGE` and/or `DRAWER_DETENT_PROTRUDE` in
+   `src/faxbox/config.py`, regenerate `calibration` (and everything else,
+   since those constants also drive the real wall/lid/faceplate geometry),
+   and re-cut before trusting the real parts' fit. Cut both flexure samples
+   with the same grain orientation the real parts will have (see DESIGN.md's
+   Grain caveat) — the faceplate sample bends across grain, the weaker
+   direction, so it's the one most likely to need tuning or a fallback to
+   magnets if the ply proves too brittle.
 4. **CorelDraw import.** NYC Resistor's workflow is CorelDraw-based; their
    tips page warns Inkscape's raw SVG export can get corrupted there and
    recommends exporting PDF instead. On import: set all strokes to

--- a/src/faxbox/calibration.py
+++ b/src/faxbox/calibration.py
@@ -19,21 +19,34 @@ on scrap BEFORE the real sheets, then:
      BURN = (measured - 10.0) / 2, then regenerate and re-cut the coupon:
      the thickness slots only read true once BURN matches the real kerf.
 
-RETENTION COUPON (iteration 2, issue #20): a SEPARATE sibling output,
-output/retention_coupon.svg (kept out of kerf_coupon.svg so its existing
-"exactly 1 piece" tests -- see tests/test_layout.py -- stay meaningful), with
-4 small pieces for tuning the two retention interference values
-(LID_DETENT_ENGAGE, DRAWER_DETENT_PROTRUDE) before cutting real
-iteration-2 parts:
+RETENTION COUPON (iteration 3, issue #20 red-team): a SEPARATE sibling
+output, output/retention_coupon.svg (kept out of kerf_coupon.svg so its
+existing "exactly 1 piece" tests -- see tests/test_layout.py -- stay
+meaningful), with pieces for tuning the two retention interference values
+(LID_DETENT_ENGAGE, DRAWER_DETENT_ENGAGE) before cutting real
+iteration-3 parts:
 
   3. Wall Flexure Sample + Lid Notch Strip: press the strip's notch over the
      sample's nub and feel it snap in/out. If it's too loose (pops out with
      a light nudge) or too stiff (won't seat without force), adjust
      LID_DETENT_ENGAGE in config.py, regenerate, and re-cut both pieces.
-  4. Faceplate Flexure Sample + Mock Opening Edge: slide the mock edge
-     across the sample's nub the way the rear-wall opening's corner would
-     slide across it on a real close, and feel the same snap. Adjust
-     DRAWER_DETENT_PROTRUDE if it's too loose/stiff, regenerate, and re-cut.
+  4. Drawer-Side Flexure Sample + Mock Sill Edge + Mock Floor Strip: this
+     one exercises the REAL travel axis, not just a press-fit -- lay the
+     sample flat, hold the Mock Sill Edge across it near the nub end and
+     slide the sample UNDER it (the nub cams up and over, same as the real
+     nub crossing the rear-wall opening's own web on insertion), then keep
+     sliding the sample across the Mock Floor Strip (the nub rides
+     deflected, same as riding the real floor/shelf) until it reaches the
+     strip's catch hole and snaps down into it. Adjust DRAWER_DETENT_ENGAGE
+     if it's too loose/stiff, regenerate, and re-cut all three.
+
+     This is also issue #20's force-criteria validation: too loose (nub
+     pops back out of the catch hole when the sample is shaken/inverted) ->
+     raise the relevant ENGAGE value by 0.25 and re-cut; can't slide the
+     sample under the sill/across the floor with one-finger force -> lower
+     it by 0.25. Iterate on scrap until both mechanisms pass, then
+     regenerate all real sheets -- see calibration.py's docstring below and
+     README step 3b for the same rule in the kerf coupon's own spirit.
 
 All cut lines are CUT_COLOR (blue) -- nothing on this coupon is engraved.
 """
@@ -46,15 +59,23 @@ from boxes import edges
 from faxbox.config import (
     FINGER_PLAY_RELATIVE,
     BURN,
+    CATCH_HOLE_X_LENGTH,
+    CATCH_HOLE_Y_WIDTH,
     CUT_COLOR,
-    DETENT_BEAM_LENGTH,
     DETENT_BEAM_WIDTH,
     DETENT_CLEARANCE,
     DETENT_ROOT_FILLET,
     DETENT_SEVER_WIDTH,
-    DRAWER_DETENT_PROTRUDE,
-    FACEPLATE_REVEAL,
+    DRAWER_DETENT_ENGAGE,
+    DRAWER_DETENT_NUB_TO_ROOT_SPAN,
+    DRAWER_DETENT_NUB_X,
+    DRAWER_DETENT_ROOT_X,
+    DRAWER_DETENT_TIP_X,
     LID_DETENT_ENGAGE,
+    LID_DETENT_NUB_TO_ROOT_SPAN,
+    LID_DETENT_ROOT_X,
+    LID_DETENT_TIP_X,
+    LID_DETENT_X,
     LID_NOTCH_CHAMFER,
     LID_NOTCH_DEPTH,
     LID_NOTCH_WIDTH,
@@ -106,9 +127,11 @@ def _item_centers() -> list[float]:
     return centers
 
 
-# --- Retention coupon geometry (iteration 2, issue #20) ----------------------
-# Four standalone pieces exercising the two mechanisms at small scale, so Ben
-# can feel the snap force and tune LID_DETENT_ENGAGE / DRAWER_DETENT_PROTRUDE
+T = MATERIAL_THICKNESS
+
+# --- Retention coupon geometry (iteration 3, issue #20 red-team) -------------
+# Standalone pieces exercising the two mechanisms at small scale, so Ben can
+# feel the snap force and tune LID_DETENT_ENGAGE / DRAWER_DETENT_ENGAGE
 # before cutting real parts. All plain-edged blanks, same conventions as the
 # kerf/fit pieces above.
 
@@ -117,8 +140,15 @@ _SAMPLE_MARGIN = 5.0
 # Wall Flexure Sample: a compact stand-in for a side wall's lid-detent area
 # -- a slot-with-nub hole across the top (the lid slot floor, with the nub
 # poking up into it) and the cantilever release cut below, both drawn with
-# the SAME faxbox.detent helpers shell_generator.py uses for the real wall.
-WALL_SAMPLE_WIDTH = DETENT_BEAM_LENGTH + 2 * _SAMPLE_MARGIN
+# the SAME faxbox.detent helpers shell_generator.py uses for the real wall,
+# at the SAME relative tip/nub/root layout as the real mechanism (FIX2: nub
+# at the beam's free end, not mid-beam) -- shifted so the tip starts
+# _SAMPLE_MARGIN in from the sample's own edge.
+_WALL_SHIFT = _SAMPLE_MARGIN - LID_DETENT_TIP_X
+WALL_SAMPLE_TIP_X = LID_DETENT_TIP_X + _WALL_SHIFT          # = _SAMPLE_MARGIN
+WALL_SAMPLE_NUB_X = LID_DETENT_X + _WALL_SHIFT
+WALL_SAMPLE_ROOT_X = LID_DETENT_ROOT_X + _WALL_SHIFT
+WALL_SAMPLE_WIDTH = WALL_SAMPLE_ROOT_X + _SAMPLE_MARGIN
 WALL_SAMPLE_FLOOR_Z = DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 3.0
 WALL_SAMPLE_HEIGHT = WALL_SAMPLE_FLOOR_Z + LID_DETENT_ENGAGE + 5.0
 
@@ -127,19 +157,62 @@ WALL_SAMPLE_HEIGHT = WALL_SAMPLE_FLOOR_Z + LID_DETENT_ENGAGE + 5.0
 NOTCH_STRIP_WIDTH = LID_NOTCH_WIDTH + 2 * _SAMPLE_MARGIN
 NOTCH_STRIP_HEIGHT = LID_NOTCH_DEPTH + _SAMPLE_MARGIN
 
-# Faceplate Flexure Sample: a compact stand-in for one faceplate Y edge --
-# the SAME nub-detour + release-cut shape generate_drawers.py cuts into the
-# real faceplate, on just one edge (a sample only needs one to demonstrate
-# the snap).
-FACE_SAMPLE_HEIGHT = DETENT_BEAM_LENGTH + 2 * _SAMPLE_MARGIN
-FACE_SAMPLE_BODY_WIDTH = DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 3.0
-FACE_SAMPLE_WIDTH = FACE_SAMPLE_BODY_WIDTH + DRAWER_DETENT_PROTRUDE
+# Drawer-Side Flexure Sample: a compact stand-in for one drawer side wall's
+# flexure zone (mechanism B, iteration 3) -- the SAME beam+nub geometry
+# generate_drawers.py cuts (nub protruding DOWN past the sample's own
+# bottom edge by T + DRAWER_DETENT_ENGAGE, same as the real side wall's
+# nub reaching past its finger tabs -- see generate_drawers.py's
+# _build_side comment), long enough to slide across the Mock Sill Edge and
+# Mock Floor Strip below, exercising the real travel axis rather than a
+# simple press-fit.
+DRAWER_SAMPLE_LEAD_IN = 10.0   # run before the tip, for a hand-hold and to
+                               # clear the Mock Sill Edge before camming
+_DRAWER_SHIFT = DRAWER_SAMPLE_LEAD_IN - DRAWER_DETENT_TIP_X
+DRAWER_SAMPLE_TIP_X = DRAWER_DETENT_TIP_X + _DRAWER_SHIFT     # = DRAWER_SAMPLE_LEAD_IN
+DRAWER_SAMPLE_NUB_X = DRAWER_DETENT_NUB_X + _DRAWER_SHIFT
+DRAWER_SAMPLE_ROOT_X = DRAWER_DETENT_ROOT_X + _DRAWER_SHIFT
+DRAWER_SAMPLE_LENGTH = DRAWER_SAMPLE_ROOT_X + _SAMPLE_MARGIN
+DRAWER_SAMPLE_NUB_DEPTH = T + DRAWER_DETENT_ENGAGE
+DRAWER_SAMPLE_HEIGHT = DRAWER_SAMPLE_NUB_DEPTH + DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 5.0
 
-# Mock Opening Edge: a plain strip representing the rear-wall opening's side
-# edge the faceplate nub snaps behind -- hold it FACEPLATE_REVEAL off the
-# faceplate sample's rest edge and slide the two together.
-MOCK_EDGE_WIDTH = 40.0
-MOCK_EDGE_HEIGHT = 15.0
+# Mock Sill Edge: a thin plain strip, T thick, representing the rear wall's
+# own cross-section at the drawer opening (DESIGN.md: "bottom opening sill
+# = floor top ... with 3.175-thick web") -- slide the sample under this
+# first; its nub cams up and over the edge, same as on a real insertion.
+MOCK_SILL_WIDTH = 30.0
+MOCK_SILL_HEIGHT = T
+
+# Mock Floor Strip: a plain strip standing in for the bay floor/shelf, with
+# ONE catch hole (same size as the real bottom-panel/shelf holes) near its
+# far end, so the sample has real "ride" distance before the nub reaches
+# it and snaps down.
+MOCK_FLOOR_WIDTH = DRAWER_SAMPLE_LENGTH
+MOCK_FLOOR_HEIGHT = 20.0
+MOCK_FLOOR_HOLE_X = DRAWER_SAMPLE_ROOT_X - 5.0
+
+
+class _SampleFlexureNubEdge(edges.Edge):
+    """Coupon-only twin of generate_drawers.py's _DrawerFlexureNubEdge (see
+    that class for the full rationale) -- duplicated rather than imported
+    since Boxes.py generators are independent Boxes subclasses with no
+    shared base to hang this on, matching this project's existing per-
+    generator duplication convention (e.g. _draw_closed_polygon)."""
+
+    def __init__(self, boxes, nub_center_local: float, peak_depth: float) -> None:
+        super().__init__(boxes, None)
+        self.nub_center_local = nub_center_local
+        self.peak_depth = peak_depth
+
+    def __call__(self, length, **kw):
+        detour = edge_nub_detour(
+            self.nub_center_local - 1.0, self.nub_center_local + 1.0,
+            0.0, -self.peak_depth, burn=self.burn,
+        )
+        self.ctx.move_to(0, 0)
+        for x, y in detour:
+            self.ctx.line_to(x, y)
+        self.ctx.line_to(length, 0)
+        self.ctx.translate(*self.ctx.get_current_point())
 
 
 class CalibrationCoupon(Boxes):
@@ -179,11 +252,11 @@ class CalibrationCoupon(Boxes):
 
 
 class RetentionCoupon(Boxes):
-    """A separate standalone sheet (issue #20): 4 small pieces exercising
-    the two retention mechanisms so LID_DETENT_ENGAGE / DRAWER_DETENT_PROTRUDE
-    can be tuned by feel before cutting real iteration-2 parts. Kept in its
-    own output file rather than appended to CalibrationCoupon's sheet, per
-    the module docstring."""
+    """A separate standalone sheet (issue #20 red-team, iteration 3): small
+    pieces exercising the two retention mechanisms so LID_DETENT_ENGAGE /
+    DRAWER_DETENT_ENGAGE can be tuned by feel before cutting real iteration-3
+    parts. Kept in its own output file rather than appended to
+    CalibrationCoupon's sheet, per the module docstring."""
 
     def __init__(self) -> None:
         Boxes.__init__(self)
@@ -202,16 +275,15 @@ class RetentionCoupon(Boxes):
             nub_top_z = WALL_SAMPLE_FLOOR_Z + LID_DETENT_ENGAGE
             points = lid_slot_with_nub_points(
                 u0=0, u1=WALL_SAMPLE_WIDTH, z0=WALL_SAMPLE_FLOOR_Z, z1=WALL_SAMPLE_HEIGHT,
-                nub_center=WALL_SAMPLE_WIDTH / 2, nub_top_z=nub_top_z,
+                nub_center=WALL_SAMPLE_NUB_X, nub_top_z=nub_top_z, burn=self.burn,
             )
             self._draw_closed_polygon(points)
 
-            tip = WALL_SAMPLE_WIDTH / 2 - DETENT_BEAM_LENGTH / 2
-            root = WALL_SAMPLE_WIDTH / 2 + DETENT_BEAM_LENGTH / 2
             beam_bottom = WALL_SAMPLE_FLOOR_Z - DETENT_BEAM_WIDTH
             cavity_bottom = beam_bottom - DETENT_CLEARANCE
             cavity, sever = release_cut_rects(
-                tip=tip, root=root, beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
+                tip=WALL_SAMPLE_TIP_X, root=WALL_SAMPLE_ROOT_X,
+                beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
                 sever_width=DETENT_SEVER_WIDTH, floor=WALL_SAMPLE_FLOOR_Z,
             )
             self.rectangularHole(*cavity, r=DETENT_ROOT_FILLET)
@@ -228,6 +300,7 @@ class RetentionCoupon(Boxes):
             points = notch_points(
                 center=NOTCH_STRIP_WIDTH / 2, width=LID_NOTCH_WIDTH, depth=LID_NOTCH_DEPTH,
                 chamfer=LID_NOTCH_CHAMFER, edge_level=0.0, inward_sign=1.0,
+                burn=self.burn,
             )
             self._draw_closed_polygon(points)
 
@@ -237,55 +310,64 @@ class RetentionCoupon(Boxes):
             move="right", label="Retention: Lid Notch Strip",
         )
 
-    def _build_faceplate_sample(self) -> None:
-        """Bypasses rectangularWall's automatic straight edges for the same
-        reason generate_drawers.py's _build_faceplate does: the nub-bearing
-        edge needs a local protrusion no Boxes.py edge class can express, so
-        the whole outline is hand-drawn (see faxbox.detent's docstring)."""
-        edge_rest = DRAWER_DETENT_PROTRUDE
-        peak = 0.0
-        tip_z = FACE_SAMPLE_HEIGHT / 2 + DETENT_BEAM_LENGTH / 2
-        root_z = FACE_SAMPLE_HEIGHT / 2 - DETENT_BEAM_LENGTH / 2
-        detour = [(x, y) for y, x in edge_nub_detour(root_z, tip_z, edge_rest, peak)]
-        outline = [
-            (edge_rest, 0.0),
-            (FACE_SAMPLE_WIDTH, 0.0),
-            (FACE_SAMPLE_WIDTH, FACE_SAMPLE_HEIGHT),
-            (edge_rest, FACE_SAMPLE_HEIGHT),
-            (edge_rest, tip_z),
-            *reversed(detour),
-        ]
+    def _build_drawer_sample(self) -> None:
+        """Drawer-Side Flexure Sample (mechanism B, iteration 3, FIX5): the
+        SAME CompoundEdge + purpose-built nub-edge technique
+        generate_drawers.py uses for the real side wall's bottom edge, at a
+        small standalone scale. Flanking segments are plain 'e' (no need to
+        replicate the real finger joints on a demo strip)."""
+        seg1 = DRAWER_SAMPLE_TIP_X
+        seg3 = _SAMPLE_MARGIN
+        seg2 = DRAWER_SAMPLE_LENGTH - seg1 - seg3
+        nub_center_local = DRAWER_SAMPLE_NUB_X - seg1
+        nub_edge = _SampleFlexureNubEdge(self, nub_center_local, DRAWER_SAMPLE_NUB_DEPTH)
+        bottom_edge = edges.CompoundEdge(self, ["e", nub_edge, "e"], [seg1, seg2, seg3])
 
-        if self.move(FACE_SAMPLE_WIDTH, FACE_SAMPLE_HEIGHT, "right", before=True):
-            return
-        self.moveTo(0, 0)
-        self.set_source_color(CUT_COLOR)
-        self._draw_closed_polygon(outline)
+        def callback() -> None:
+            beam_top = DETENT_BEAM_WIDTH
+            cavity_top = DETENT_BEAM_WIDTH + DETENT_CLEARANCE
+            cavity, sever = release_cut_rects(
+                tip=DRAWER_SAMPLE_TIP_X, root=DRAWER_SAMPLE_ROOT_X,
+                beam_bottom=beam_top, cavity_bottom=cavity_top,
+                sever_width=DETENT_SEVER_WIDTH, floor=0.0,
+            )
+            self.rectangularHole(*cavity, r=DETENT_ROOT_FILLET)
+            self.rectangularHole(*sever, r=DETENT_ROOT_FILLET)
 
-        beam_bottom = edge_rest + DETENT_BEAM_WIDTH
-        cavity_bottom = beam_bottom + DETENT_CLEARANCE
-        cavity, sever = release_cut_rects(
-            tip=tip_z, root=root_z, beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
-            sever_width=DETENT_SEVER_WIDTH, floor=edge_rest,
-        )
-        for cx, cy, dx, dy in (cavity, sever):
-            self.rectangularHole(cy, cx, dy, dx, r=DETENT_ROOT_FILLET)
-
-        self.move(FACE_SAMPLE_WIDTH, FACE_SAMPLE_HEIGHT, "right", label="Retention: Faceplate Flexure Sample")
-
-    def _build_mock_opening_edge(self) -> None:
         self.rectangularWall(
-            MOCK_EDGE_WIDTH, MOCK_EDGE_HEIGHT, "eeee",
-            move="right", label="Retention: Mock Opening Edge",
+            DRAWER_SAMPLE_LENGTH, DRAWER_SAMPLE_HEIGHT,
+            [bottom_edge, self.edges["e"], self.edges["e"], self.edges["e"]],
+            callback=[callback, None, None, None],
+            move="right", label="Retention: Drawer-Side Flexure Sample",
+        )
+
+    def _build_mock_sill_edge(self) -> None:
+        self.rectangularWall(
+            MOCK_SILL_WIDTH, MOCK_SILL_HEIGHT, "eeee",
+            move="right", label="Retention: Mock Sill Edge",
+        )
+
+    def _build_mock_floor_strip(self) -> None:
+        def callback() -> None:
+            self.rectangularHole(
+                MOCK_FLOOR_HOLE_X, MOCK_FLOOR_HEIGHT / 2,
+                CATCH_HOLE_X_LENGTH, CATCH_HOLE_Y_WIDTH, r=0,
+            )
+
+        self.rectangularWall(
+            MOCK_FLOOR_WIDTH, MOCK_FLOOR_HEIGHT, "eeee",
+            callback=[callback, None, None, None],
+            move="right", label="Retention: Mock Floor Strip",
         )
 
     def render(self) -> None:
-        """Render all 4 retention-coupon pieces in a single row."""
+        """Render all retention-coupon pieces in a single row."""
         self.set_source_color(CUT_COLOR)
         self._build_wall_sample()
         self._build_notch_strip()
-        self._build_faceplate_sample()
-        self._build_mock_opening_edge()
+        self._build_drawer_sample()
+        self._build_mock_sill_edge()
+        self._build_mock_floor_strip()
 
 
 def generate_calibration() -> Path:
@@ -334,9 +416,10 @@ def generate_calibration() -> Path:
 
 
 def generate_retention_coupon() -> Path:
-    """Generate the retention coupon SVG file (issue #20): 4 small pieces
-    for tuning LID_DETENT_ENGAGE / DRAWER_DETENT_PROTRUDE by feel before
-    cutting real iteration-2 parts. See this module's docstring.
+    """Generate the retention coupon SVG file (issue #20 red-team,
+    iteration 3): 5 small pieces for tuning LID_DETENT_ENGAGE /
+    DRAWER_DETENT_ENGAGE by feel before cutting real iteration-3 parts.
+    See this module's docstring.
 
     Returns:
         Path to the generated SVG file.
@@ -362,13 +445,15 @@ def generate_retention_coupon() -> Path:
         f.write(data.getvalue())
 
     print(f"Generated retention coupon SVG: {output_file.absolute()}")
-    print("  Cut this on scrap BEFORE the real iteration-2 parts. Pieces:")
+    print("  Cut this on scrap BEFORE the real iteration-3 parts. Pieces:")
     print("    - Wall Flexure Sample + Lid Notch Strip: press the notch over the")
     print("      sample's nub and feel it snap. Tune LID_DETENT_ENGAGE if it's")
     print("      too loose/stiff, regenerate, and re-cut both.")
-    print("    - Faceplate Flexure Sample + Mock Opening Edge: slide the mock edge")
-    print("      across the sample's nub the way a real close would, and feel the")
-    print("      same snap. Tune DRAWER_DETENT_PROTRUDE, regenerate, and re-cut.")
+    print("    - Drawer-Side Flexure Sample + Mock Sill Edge + Mock Floor Strip:")
+    print("      slide the sample under the sill edge (nub cams up and over, same")
+    print("      as a real insertion), then across the floor strip until it drops")
+    print("      into the catch hole and snaps. Tune DRAWER_DETENT_ENGAGE if it's")
+    print("      too loose/stiff, regenerate, and re-cut all three.")
     return output_file
 
 

--- a/src/faxbox/calibration.py
+++ b/src/faxbox/calibration.py
@@ -63,14 +63,15 @@ from faxbox.config import (
     CATCH_HOLE_Y_WIDTH,
     CUT_COLOR,
     DETENT_BEAM_WIDTH,
-    DETENT_CLEARANCE,
     DETENT_ROOT_FILLET,
     DETENT_SEVER_WIDTH,
+    DRAWER_DETENT_CAVITY,
     DRAWER_DETENT_ENGAGE,
     DRAWER_DETENT_NUB_TO_ROOT_SPAN,
     DRAWER_DETENT_NUB_X,
     DRAWER_DETENT_ROOT_X,
     DRAWER_DETENT_TIP_X,
+    LID_DETENT_CAVITY,
     LID_DETENT_ENGAGE,
     LID_DETENT_NUB_TO_ROOT_SPAN,
     LID_DETENT_ROOT_X,
@@ -149,7 +150,7 @@ WALL_SAMPLE_TIP_X = LID_DETENT_TIP_X + _WALL_SHIFT          # = _SAMPLE_MARGIN
 WALL_SAMPLE_NUB_X = LID_DETENT_X + _WALL_SHIFT
 WALL_SAMPLE_ROOT_X = LID_DETENT_ROOT_X + _WALL_SHIFT
 WALL_SAMPLE_WIDTH = WALL_SAMPLE_ROOT_X + _SAMPLE_MARGIN
-WALL_SAMPLE_FLOOR_Z = DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 3.0
+WALL_SAMPLE_FLOOR_Z = DETENT_BEAM_WIDTH + LID_DETENT_CAVITY + 3.0
 WALL_SAMPLE_HEIGHT = WALL_SAMPLE_FLOOR_Z + LID_DETENT_ENGAGE + 5.0
 
 # Lid Notch Strip: a short stand-in for the lid's mating edge, carrying the
@@ -173,7 +174,7 @@ DRAWER_SAMPLE_NUB_X = DRAWER_DETENT_NUB_X + _DRAWER_SHIFT
 DRAWER_SAMPLE_ROOT_X = DRAWER_DETENT_ROOT_X + _DRAWER_SHIFT
 DRAWER_SAMPLE_LENGTH = DRAWER_SAMPLE_ROOT_X + _SAMPLE_MARGIN
 DRAWER_SAMPLE_NUB_DEPTH = T + DRAWER_DETENT_ENGAGE
-DRAWER_SAMPLE_HEIGHT = DRAWER_SAMPLE_NUB_DEPTH + DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 5.0
+DRAWER_SAMPLE_HEIGHT = DRAWER_SAMPLE_NUB_DEPTH + DETENT_BEAM_WIDTH + DRAWER_DETENT_CAVITY + 5.0
 
 # Mock Sill Edge: a thin plain strip, T thick, representing the rear wall's
 # own cross-section at the drawer opening (DESIGN.md: "bottom opening sill
@@ -280,7 +281,7 @@ class RetentionCoupon(Boxes):
             self._draw_closed_polygon(points)
 
             beam_bottom = WALL_SAMPLE_FLOOR_Z - DETENT_BEAM_WIDTH
-            cavity_bottom = beam_bottom - DETENT_CLEARANCE
+            cavity_bottom = beam_bottom - LID_DETENT_CAVITY
             cavity, sever = release_cut_rects(
                 tip=WALL_SAMPLE_TIP_X, root=WALL_SAMPLE_ROOT_X,
                 beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
@@ -325,7 +326,7 @@ class RetentionCoupon(Boxes):
 
         def callback() -> None:
             beam_top = DETENT_BEAM_WIDTH
-            cavity_top = DETENT_BEAM_WIDTH + DETENT_CLEARANCE
+            cavity_top = DETENT_BEAM_WIDTH + DRAWER_DETENT_CAVITY
             cavity, sever = release_cut_rects(
                 tip=DRAWER_SAMPLE_TIP_X, root=DRAWER_SAMPLE_ROOT_X,
                 beam_bottom=beam_top, cavity_bottom=cavity_top,

--- a/src/faxbox/calibration.py
+++ b/src/faxbox/calibration.py
@@ -19,6 +19,22 @@ on scrap BEFORE the real sheets, then:
      BURN = (measured - 10.0) / 2, then regenerate and re-cut the coupon:
      the thickness slots only read true once BURN matches the real kerf.
 
+RETENTION COUPON (iteration 2, issue #20): a SEPARATE sibling output,
+output/retention_coupon.svg (kept out of kerf_coupon.svg so its existing
+"exactly 1 piece" tests -- see tests/test_layout.py -- stay meaningful), with
+4 small pieces for tuning the two retention interference values
+(LID_DETENT_ENGAGE, DRAWER_DETENT_PROTRUDE) before cutting real
+iteration-2 parts:
+
+  3. Wall Flexure Sample + Lid Notch Strip: press the strip's notch over the
+     sample's nub and feel it snap in/out. If it's too loose (pops out with
+     a light nudge) or too stiff (won't seat without force), adjust
+     LID_DETENT_ENGAGE in config.py, regenerate, and re-cut both pieces.
+  4. Faceplate Flexure Sample + Mock Opening Edge: slide the mock edge
+     across the sample's nub the way the rear-wall opening's corner would
+     slide across it on a real close, and feel the same snap. Adjust
+     DRAWER_DETENT_PROTRUDE if it's too loose/stiff, regenerate, and re-cut.
+
 All cut lines are CUT_COLOR (blue) -- nothing on this coupon is engraved.
 """
 
@@ -31,9 +47,21 @@ from faxbox.config import (
     FINGER_PLAY_RELATIVE,
     BURN,
     CUT_COLOR,
+    DETENT_BEAM_LENGTH,
+    DETENT_BEAM_WIDTH,
+    DETENT_CLEARANCE,
+    DETENT_ROOT_FILLET,
+    DETENT_SEVER_WIDTH,
+    DRAWER_DETENT_PROTRUDE,
+    FACEPLATE_REVEAL,
+    LID_DETENT_ENGAGE,
+    LID_NOTCH_CHAMFER,
+    LID_NOTCH_DEPTH,
+    LID_NOTCH_WIDTH,
     MATERIAL_THICKNESS,
     OUTPUT_DIR,
 )
+from faxbox.detent import edge_nub_detour, lid_slot_with_nub_points, notch_points, release_cut_rects
 
 # --- Coupon geometry ---------------------------------------------------------
 
@@ -78,6 +106,42 @@ def _item_centers() -> list[float]:
     return centers
 
 
+# --- Retention coupon geometry (iteration 2, issue #20) ----------------------
+# Four standalone pieces exercising the two mechanisms at small scale, so Ben
+# can feel the snap force and tune LID_DETENT_ENGAGE / DRAWER_DETENT_PROTRUDE
+# before cutting real parts. All plain-edged blanks, same conventions as the
+# kerf/fit pieces above.
+
+_SAMPLE_MARGIN = 5.0
+
+# Wall Flexure Sample: a compact stand-in for a side wall's lid-detent area
+# -- a slot-with-nub hole across the top (the lid slot floor, with the nub
+# poking up into it) and the cantilever release cut below, both drawn with
+# the SAME faxbox.detent helpers shell_generator.py uses for the real wall.
+WALL_SAMPLE_WIDTH = DETENT_BEAM_LENGTH + 2 * _SAMPLE_MARGIN
+WALL_SAMPLE_FLOOR_Z = DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 3.0
+WALL_SAMPLE_HEIGHT = WALL_SAMPLE_FLOOR_Z + LID_DETENT_ENGAGE + 5.0
+
+# Lid Notch Strip: a short stand-in for the lid's mating edge, carrying the
+# same notch generate_lids.py cuts into the real lid.
+NOTCH_STRIP_WIDTH = LID_NOTCH_WIDTH + 2 * _SAMPLE_MARGIN
+NOTCH_STRIP_HEIGHT = LID_NOTCH_DEPTH + _SAMPLE_MARGIN
+
+# Faceplate Flexure Sample: a compact stand-in for one faceplate Y edge --
+# the SAME nub-detour + release-cut shape generate_drawers.py cuts into the
+# real faceplate, on just one edge (a sample only needs one to demonstrate
+# the snap).
+FACE_SAMPLE_HEIGHT = DETENT_BEAM_LENGTH + 2 * _SAMPLE_MARGIN
+FACE_SAMPLE_BODY_WIDTH = DETENT_BEAM_WIDTH + DETENT_CLEARANCE + 3.0
+FACE_SAMPLE_WIDTH = FACE_SAMPLE_BODY_WIDTH + DRAWER_DETENT_PROTRUDE
+
+# Mock Opening Edge: a plain strip representing the rear-wall opening's side
+# edge the faceplate nub snaps behind -- hold it FACEPLATE_REVEAL off the
+# faceplate sample's rest edge and slide the two together.
+MOCK_EDGE_WIDTH = 40.0
+MOCK_EDGE_HEIGHT = 15.0
+
+
 class CalibrationCoupon(Boxes):
     """A single small standalone panel: 3 fit-test slots + 1 kerf-test hole."""
 
@@ -112,6 +176,116 @@ class CalibrationCoupon(Boxes):
             callback=[callback, None, None, None],
             move="right", label="Kerf Coupon",
         )
+
+
+class RetentionCoupon(Boxes):
+    """A separate standalone sheet (issue #20): 4 small pieces exercising
+    the two retention mechanisms so LID_DETENT_ENGAGE / DRAWER_DETENT_PROTRUDE
+    can be tuned by feel before cutting real iteration-2 parts. Kept in its
+    own output file rather than appended to CalibrationCoupon's sheet, per
+    the module docstring."""
+
+    def __init__(self) -> None:
+        Boxes.__init__(self)
+        self.addSettingsArgs(edges.FingerJointSettings)
+
+    def _draw_closed_polygon(self, points: list[tuple[float, float]]) -> None:
+        """Stroke a closed polygon -- see faxbox.detent module docstring."""
+        self.ctx.move_to(*points[0])
+        for pt in points[1:]:
+            self.ctx.line_to(*pt)
+        self.ctx.line_to(*points[0])
+        self.ctx.stroke()
+
+    def _build_wall_sample(self) -> None:
+        def callback() -> None:
+            nub_top_z = WALL_SAMPLE_FLOOR_Z + LID_DETENT_ENGAGE
+            points = lid_slot_with_nub_points(
+                u0=0, u1=WALL_SAMPLE_WIDTH, z0=WALL_SAMPLE_FLOOR_Z, z1=WALL_SAMPLE_HEIGHT,
+                nub_center=WALL_SAMPLE_WIDTH / 2, nub_top_z=nub_top_z,
+            )
+            self._draw_closed_polygon(points)
+
+            tip = WALL_SAMPLE_WIDTH / 2 - DETENT_BEAM_LENGTH / 2
+            root = WALL_SAMPLE_WIDTH / 2 + DETENT_BEAM_LENGTH / 2
+            beam_bottom = WALL_SAMPLE_FLOOR_Z - DETENT_BEAM_WIDTH
+            cavity_bottom = beam_bottom - DETENT_CLEARANCE
+            cavity, sever = release_cut_rects(
+                tip=tip, root=root, beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
+                sever_width=DETENT_SEVER_WIDTH, floor=WALL_SAMPLE_FLOOR_Z,
+            )
+            self.rectangularHole(*cavity, r=DETENT_ROOT_FILLET)
+            self.rectangularHole(*sever, r=DETENT_ROOT_FILLET)
+
+        self.rectangularWall(
+            WALL_SAMPLE_WIDTH, WALL_SAMPLE_HEIGHT, "eeee",
+            callback=[callback, None, None, None],
+            move="right", label="Retention: Wall Flexure Sample",
+        )
+
+    def _build_notch_strip(self) -> None:
+        def callback() -> None:
+            points = notch_points(
+                center=NOTCH_STRIP_WIDTH / 2, width=LID_NOTCH_WIDTH, depth=LID_NOTCH_DEPTH,
+                chamfer=LID_NOTCH_CHAMFER, edge_level=0.0, inward_sign=1.0,
+            )
+            self._draw_closed_polygon(points)
+
+        self.rectangularWall(
+            NOTCH_STRIP_WIDTH, NOTCH_STRIP_HEIGHT, "eeee",
+            callback=[callback, None, None, None],
+            move="right", label="Retention: Lid Notch Strip",
+        )
+
+    def _build_faceplate_sample(self) -> None:
+        """Bypasses rectangularWall's automatic straight edges for the same
+        reason generate_drawers.py's _build_faceplate does: the nub-bearing
+        edge needs a local protrusion no Boxes.py edge class can express, so
+        the whole outline is hand-drawn (see faxbox.detent's docstring)."""
+        edge_rest = DRAWER_DETENT_PROTRUDE
+        peak = 0.0
+        tip_z = FACE_SAMPLE_HEIGHT / 2 + DETENT_BEAM_LENGTH / 2
+        root_z = FACE_SAMPLE_HEIGHT / 2 - DETENT_BEAM_LENGTH / 2
+        detour = [(x, y) for y, x in edge_nub_detour(root_z, tip_z, edge_rest, peak)]
+        outline = [
+            (edge_rest, 0.0),
+            (FACE_SAMPLE_WIDTH, 0.0),
+            (FACE_SAMPLE_WIDTH, FACE_SAMPLE_HEIGHT),
+            (edge_rest, FACE_SAMPLE_HEIGHT),
+            (edge_rest, tip_z),
+            *reversed(detour),
+        ]
+
+        if self.move(FACE_SAMPLE_WIDTH, FACE_SAMPLE_HEIGHT, "right", before=True):
+            return
+        self.moveTo(0, 0)
+        self.set_source_color(CUT_COLOR)
+        self._draw_closed_polygon(outline)
+
+        beam_bottom = edge_rest + DETENT_BEAM_WIDTH
+        cavity_bottom = beam_bottom + DETENT_CLEARANCE
+        cavity, sever = release_cut_rects(
+            tip=tip_z, root=root_z, beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
+            sever_width=DETENT_SEVER_WIDTH, floor=edge_rest,
+        )
+        for cx, cy, dx, dy in (cavity, sever):
+            self.rectangularHole(cy, cx, dy, dx, r=DETENT_ROOT_FILLET)
+
+        self.move(FACE_SAMPLE_WIDTH, FACE_SAMPLE_HEIGHT, "right", label="Retention: Faceplate Flexure Sample")
+
+    def _build_mock_opening_edge(self) -> None:
+        self.rectangularWall(
+            MOCK_EDGE_WIDTH, MOCK_EDGE_HEIGHT, "eeee",
+            move="right", label="Retention: Mock Opening Edge",
+        )
+
+    def render(self) -> None:
+        """Render all 4 retention-coupon pieces in a single row."""
+        self.set_source_color(CUT_COLOR)
+        self._build_wall_sample()
+        self._build_notch_strip()
+        self._build_faceplate_sample()
+        self._build_mock_opening_edge()
 
 
 def generate_calibration() -> Path:
@@ -159,5 +333,45 @@ def generate_calibration() -> Path:
     return output_file
 
 
+def generate_retention_coupon() -> Path:
+    """Generate the retention coupon SVG file (issue #20): 4 small pieces
+    for tuning LID_DETENT_ENGAGE / DRAWER_DETENT_PROTRUDE by feel before
+    cutting real iteration-2 parts. See this module's docstring.
+
+    Returns:
+        Path to the generated SVG file.
+    """
+    output_path = Path(OUTPUT_DIR)
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_file = output_path / "retention_coupon.svg"
+
+    coupon = RetentionCoupon()
+    coupon.parseArgs([
+        "--output", str(output_file),
+        "--thickness", str(MATERIAL_THICKNESS),
+        "--burn", str(BURN),
+        "--reference", "0",
+        "--FingerJoint_play", str(FINGER_PLAY_RELATIVE),
+    ])
+
+    coupon.open()
+    coupon.render()
+    data = coupon.close()
+
+    with open(output_file, "wb") as f:
+        f.write(data.getvalue())
+
+    print(f"Generated retention coupon SVG: {output_file.absolute()}")
+    print("  Cut this on scrap BEFORE the real iteration-2 parts. Pieces:")
+    print("    - Wall Flexure Sample + Lid Notch Strip: press the notch over the")
+    print("      sample's nub and feel it snap. Tune LID_DETENT_ENGAGE if it's")
+    print("      too loose/stiff, regenerate, and re-cut both.")
+    print("    - Faceplate Flexure Sample + Mock Opening Edge: slide the mock edge")
+    print("      across the sample's nub the way a real close would, and feel the")
+    print("      same snap. Tune DRAWER_DETENT_PROTRUDE, regenerate, and re-cut.")
+    return output_file
+
+
 if __name__ == "__main__":
     generate_calibration()
+    generate_retention_coupon()

--- a/src/faxbox/config.py
+++ b/src/faxbox/config.py
@@ -8,6 +8,8 @@ Coordinate convention (DESIGN.md): origin at the exterior front-left-bottom
 corner. X+ rearward (length, 12"), Y+ rightward (width, 6.5"), Z+ up (5").
 """
 
+import math
+
 # --- Material & laser -------------------------------------------------------
 
 MATERIAL_THICKNESS = 3.175  # 1/8" plywood, uniform for ALL parts (SPEC)
@@ -134,6 +136,100 @@ ENGRAVE_TEXT = "FAX MACHINE"
 ENGRAVE_PIXEL_SIZE = 4.0          # 5x7 pixel font cell size
 ENGRAVE_FONT_SPACING = 2.0        # gap between letters
 ENGRAVE_CENTER = {"x": SHELL_EXT["length"] / 2, "z": 63.5}  # right wall exterior
+
+# --- Retention (iteration 2, issue #20) --------------------------------------
+# Two in-plane laser-cut cantilever spring detents, adapted from Boxes.py's
+# own precedents (boxes/edges.py SlideOnLidSettings/LidRight: spring finger
+# length min(6t, ...), 30 degree tip ramp, catch-hole depth 0.4t; boxes/
+# generators/dinrailbox.py: a cantilever tongue with a nub cut directly into
+# a panel). We adapt the *proportions* of those precedents, not their play
+# values (they assume ~0.3mm clearance; this project's slide clearances are
+# deliberately looser, see SLIDE_CLEARANCE / LID_SLOT_VERTICAL_CLEARANCE
+# above) -- see DESIGN.md's "Retention (iteration 2)" section for the full
+# derivation and coordinates.
+#
+# Mechanism A (side walls): a cantilever cut into the wall material just
+# below the lid slot floor, with a ramped nub poking up through the floor
+# into the slot cavity -- the lid's closed position carries a matching
+# edge-open notch that the nub pops into.
+# Mechanism B (drawer faceplates): a cantilever cut near each Y side edge of
+# the faceplate, with a ramped nub poking out sideways past the faceplate's
+# own edge -- it snaps past the rear-wall opening's side edge on close.
+
+# Nub engagement / interference depths (the two values Ben tunes against the
+# retention coupon before cutting real parts -- see calibration.py).
+LID_DETENT_ENGAGE = 1.5        # nub rise above the lid slot floor (mm); must
+                                # exceed LID_SLOT_VERTICAL_CLEARANCE (0.8) so
+                                # the nub stays engaged when the lid shifts
+                                # within its own vertical play.
+DRAWER_DETENT_PROTRUDE = 1.2   # nub protrusion beyond the faceplate edge
+                                # (mm); 0.45mm interference past the 0.75mm
+                                # FACEPLATE_REVEAL when the faceplate is
+                                # centered in its opening.
+
+# Shared cantilever proportions (both mechanisms use the same beam stock;
+# only the nub height/protrusion differs per mechanism above).
+DETENT_BEAM_LENGTH = 18.0       # cantilever length (mm)
+DETENT_BEAM_WIDTH = 2.5         # beam cross-section width in the flex
+                                # direction (mm) -- the dimension that bends
+DETENT_ROOT_FILLET = 1.0        # minimum root fillet radius (mm)
+DETENT_CLEARANCE = 2.5          # clearance behind/below the beam so it can
+                                # deflect its own engagement depth without
+                                # bottoming out (mm)
+DETENT_RAMP_DEG = 30.0          # nub ramp angle from the beam's rest plane,
+                                # matching Boxes.py LidRight's barb angle `a`
+DETENT_SEVER_WIDTH = 1.0        # width of the release cut that frees the
+                                # beam's tip from the surrounding material
+                                # (mm) -- well above kerf so it fully parts
+DETENT_NUB_TOP_WIDTH = 2.5      # flat land at the nub's tip (mm); a flat
+                                # top (rather than a knife edge) avoids the
+                                # stress-concentrating point a bare 30 degree
+                                # wedge would leave in cross-grain plywood
+
+# --- Mechanism A: side-wall lid detent ---------------------------------------
+# Nub centered on the beam (LID_DETENT_X +/- half the beam length); the free
+# (severed) end sits toward the wall's front (mouth) edge, the root end is
+# solid, deeper into the wall -- clear of both the front-edge finger joints
+# (below LID_SLOT_BOTTOM only) and the divider hole line (79.375-82.55).
+LID_DETENT_X = 20.0             # box X, nub center (both walls; the mirror
+                                 # convention in shell_generator.py lands
+                                 # both walls' nubs at this same real box X)
+LID_DETENT_TIP_X = LID_DETENT_X - DETENT_BEAM_LENGTH / 2   # 11.0, free/severed end
+LID_DETENT_ROOT_X = LID_DETENT_X + DETENT_BEAM_LENGTH / 2  # 29.0, solid anchor end
+
+LID_DETENT_RAMP_RUN = LID_DETENT_ENGAGE / math.tan(math.radians(DETENT_RAMP_DEG))
+LID_DETENT_NUB_BASE_WIDTH = DETENT_NUB_TOP_WIDTH + 2 * LID_DETENT_RAMP_RUN  # ~7.7
+
+LID_DETENT_NUB_TOP_Z = LID_SLOT_BOTTOM + LID_DETENT_ENGAGE          # 119.525
+LID_DETENT_BEAM_BOTTOM_Z = LID_SLOT_BOTTOM - DETENT_BEAM_WIDTH      # 115.525
+LID_DETENT_CAVITY_BOTTOM_Z = LID_DETENT_BEAM_BOTTOM_Z - DETENT_CLEARANCE  # 113.025
+
+# Mating notch in the lid's side edges (DESIGN.md #8: closed lid front edge
+# sits at box X = LID_SLOT_X_END - SLIDING_LID["length"], "~0.4mm shy" of the
+# front face -- lid-local X = box X - that offset).
+LID_CLOSED_FRONT_X = LID_SLOT_X_END - SLIDING_LID["length"]        # 0.375
+LID_NOTCH_X = LID_DETENT_X - LID_CLOSED_FRONT_X                    # 19.625, lid-local
+LID_NOTCH_WIDTH = LID_DETENT_NUB_BASE_WIDTH + 1.0                  # ~8.7
+LID_NOTCH_DEPTH = 3.0                # >= LID lid-slot engagement (2.425) + margin
+LID_NOTCH_CHAMFER = 1.0              # corner ease at the notch mouth (mm)
+
+# --- Mechanism B: drawer faceplate detent ------------------------------------
+# Nub Z-center at the faceplate's mid-height -- beside (never intersecting)
+# the Y-centered grip slot, which sits ~60mm away in Y. Root end toward the
+# bottom edge, free/severed (tip) end toward the top -- an arbitrary but
+# consistent choice; the grip slot's Y-separation is what actually keeps the
+# two features apart, not the Z split.
+DRAWER_DETENT_Z = FACEPLATE["height"] / 2                          # 26.75
+DRAWER_DETENT_ROOT_Z = DRAWER_DETENT_Z - DETENT_BEAM_LENGTH / 2    # 17.75
+DRAWER_DETENT_TIP_Z = DRAWER_DETENT_Z + DETENT_BEAM_LENGTH / 2     # 35.75
+
+DRAWER_DETENT_RAMP_RUN = DRAWER_DETENT_PROTRUDE / math.tan(math.radians(DETENT_RAMP_DEG))
+DRAWER_DETENT_NUB_BASE_WIDTH = DETENT_NUB_TOP_WIDTH + 2 * DRAWER_DETENT_RAMP_RUN  # ~6.66
+
+# Faceplate's true drawn footprint, including both nubs (DESIGN.md #9,
+# amended): the outer boundary is drawn offset by DRAWER_DETENT_PROTRUDE so
+# the leftmost nub tip sits at local x=0 (see generate_drawers.py).
+FACEPLATE_DRAWN_WIDTH = FACEPLATE["width"] + 2 * DRAWER_DETENT_PROTRUDE  # 153.3
 
 # --- Output ------------------------------------------------------------------
 

--- a/src/faxbox/config.py
+++ b/src/faxbox/config.py
@@ -175,9 +175,6 @@ DRAWER_DETENT_ENGAGE = 2.2     # nub protrusion below the drawer side wall's
 DETENT_BEAM_WIDTH = 2.5         # beam cross-section width in the flex
                                 # direction (mm) -- the dimension that bends
 DETENT_ROOT_FILLET = 1.0        # minimum root fillet radius (mm)
-DETENT_CLEARANCE = 2.5          # clearance behind/below the beam so it can
-                                # deflect its own engagement depth without
-                                # bottoming out (mm)
 DETENT_RAMP_DEG = 30.0          # nub ramp angle from the beam's rest plane,
                                 # matching Boxes.py LidRight's barb angle `a`
 DETENT_SEVER_WIDTH = 1.0        # width of the release cut that frees the
@@ -207,6 +204,34 @@ def _nub_base_width(rise: float) -> float:
     return DETENT_NUB_TOP_WIDTH + 2 * _ramp_run(rise)
 
 
+def _tip_rise(engage: float, overhang: float, span: float) -> float:
+    """Free-tip rise of a cantilever beam under a concentrated nub load,
+    when the beam's severed free end extends `overhang` mm PAST the nub's
+    own load point, toward the tip (root-to-nub span `span`; both mechanisms
+    put the nub near, but not exactly at, the free tip -- see
+    DETENT_SEVER_CLEARANCE) -- issue #20 red-team pass-3 F3.
+
+    A point load a distance `span` from a fixed root deflects that point by
+    `engage` (the nub's own designed rise); standard cantilever beam theory
+    (constant EI) gives the ADDITIONAL deflection at a point `overhang`
+    further out, past the load, as linear in the load-point's own rotation
+    there -- for a fixed-root beam this works out to a tip deflection of
+    engage * (1 + 3*overhang / (2*span)), i.e. the tip always rises MORE
+    than the nub's own rise if it overhangs past it. Pass-2's design only
+    sized the clearance CAVITY to the nub's own rise (`engage`), so a beam
+    whose free tip overhangs the nub by very much would try to rise further
+    than the cavity is deep and BIND before reaching full engagement --
+    exactly what happened to the drawer mechanism (see DRAWER_DETENT_CAVITY
+    below): tip rise ~2.97mm > the shared 2.5mm cavity of that revision ->
+    binds at ~1.85mm, short of the designed 2.2mm engagement. The lid
+    mechanism's tip rise (~2.0mm) already fit under its 2.5mm cavity by
+    coincidence -- this formula makes that margin explicit instead of
+    accidental, and lets the drawer mechanism's cavity be sized correctly
+    too (see DESIGN.md's "Retention" section).
+    """
+    return engage * (1 + 3 * overhang / (2 * span))
+
+
 # --- Mechanism A: side-wall lid detent ---------------------------------------
 # The nub sits at the beam's FREE end (FIX2, red-team pass 2: the previous
 # revision put the nub mid-beam at X=20 with root at X=29, a 9mm root-to-nub
@@ -230,9 +255,28 @@ LID_DETENT_NUB_BASE_WIDTH = _nub_base_width(LID_DETENT_ENGAGE)   # ~7.70
 LID_DETENT_TIP_X = LID_DETENT_X - LID_DETENT_NUB_BASE_WIDTH / 2 - DETENT_SEVER_CLEARANCE  # ~14.65, free/severed end
 LID_DETENT_ROOT_X = LID_DETENT_X + LID_DETENT_NUB_TO_ROOT_SPAN                            # 42.0, solid anchor end
 
+# Free-tip rise at full LID_DETENT_ENGAGE deflection (F3, issue #20 pass-3):
+# the beam's severed free end sits DETENT_SEVER_WIDTH/2 past LID_DETENT_TIP_X
+# (the sever cut's own center), which is itself DETENT_SEVER_CLEARANCE +
+# half the nub's base outward of the nub -- that whole offset is the
+# "overhang" the tip rises through in ADDITION to the nub's own designed
+# rise. Cavity = tip rise + 0.5mm real margin so the beam can reach full
+# engagement without binding on the cavity's far wall.
+LID_DETENT_FREE_TIP_X = LID_DETENT_TIP_X + DETENT_SEVER_WIDTH / 2       # ~15.15
+LID_DETENT_TIP_OVERHANG = LID_DETENT_X - LID_DETENT_FREE_TIP_X          # ~4.85
+LID_DETENT_TIP_RISE = _tip_rise(
+    LID_DETENT_ENGAGE, LID_DETENT_TIP_OVERHANG, LID_DETENT_NUB_TO_ROOT_SPAN)  # ~2.00
+LID_DETENT_CAVITY = LID_DETENT_TIP_RISE + 0.5                           # ~2.50 (unchanged
+                                                                         # from the old shared
+                                                                         # DETENT_CLEARANCE --
+                                                                         # this mechanism's tip
+                                                                         # rise already had a
+                                                                         # real, if accidental,
+                                                                         # margin)
+
 LID_DETENT_NUB_TOP_Z = LID_SLOT_BOTTOM + LID_DETENT_ENGAGE          # 119.525
 LID_DETENT_BEAM_BOTTOM_Z = LID_SLOT_BOTTOM - DETENT_BEAM_WIDTH      # 115.525
-LID_DETENT_CAVITY_BOTTOM_Z = LID_DETENT_BEAM_BOTTOM_Z - DETENT_CLEARANCE  # 113.025
+LID_DETENT_CAVITY_BOTTOM_Z = LID_DETENT_BEAM_BOTTOM_Z - LID_DETENT_CAVITY  # ~113.03
 
 # Mating notch in the lid's side edges (DESIGN.md #8: closed lid front edge
 # sits at box X = LID_SLOT_X_END - SLIDING_LID["length"], "~0.4mm shy" of the
@@ -268,23 +312,88 @@ LID_NOTCH_CHAMFER = 1.0              # corner ease at the notch mouth (mm)
 # a real margin below the ~1.5-2% plywood cracking threshold.
 DRAWER_DETENT_NUB_TO_ROOT_SPAN = 26.0
 
-DRAWER_DETENT_NUB_BASE_WIDTH = _nub_base_width(DRAWER_DETENT_ENGAGE)  # ~10.12
+# Nub width at two different reference planes along its ramp (F4 rename,
+# issue #20 pass-3): the taper is linear (constant DETENT_RAMP_DEG), so its
+# half-width simply grows by ramp_run(x) for every mm `x` traveled back UP
+# the ramp from its narrow tip -- these are the same function evaluated at
+# two different depths, NOT the same number:
+# - NUB_WIDTH_AT_FLOOR_PLANE: width DRAWER_DETENT_ENGAGE above the very tip,
+#   i.e. at the drawer's TRUE exterior bottom (the plane the nub is 2.2mm
+#   proud of) -- this is the cross-section that actually threads through a
+#   catch hole, so catch-hole X-length must reference THIS value (below).
+#   The previous revision named this `DRAWER_DETENT_NUB_BASE_WIDTH` even
+#   though it is measured from the FLOOR plane, not the wall/base plane --
+#   renamed here, value unchanged (~10.12).
+# - NUB_WIDTH_AT_WALL_PLANE: width (T + DRAWER_DETENT_ENGAGE) above the tip,
+#   i.e. at the wall's own plain-zone baseline (local y=0), where the nub is
+#   still flush with the wall's bulk material -- this is the nub's WIDEST
+#   cross-section (~21.1 nominal, ~21.4 as-cut with BURN), and what the
+#   drawer's own Bottom panel clearance slot (below, F2) must actually
+#   clear, since the panel sits directly under this plane.
+NUB_WIDTH_AT_FLOOR_PLANE = _nub_base_width(DRAWER_DETENT_ENGAGE)          # ~10.12
+NUB_WIDTH_AT_WALL_PLANE = _nub_base_width(T + DRAWER_DETENT_ENGAGE)       # ~21.12
 
 # Nub position (drawer-local X, front/faceplate end): far enough from the
 # front finger joints (>=15mm clear, per issue instructions) even after
 # backing out DETENT_SEVER_CLEARANCE + the nub's own half-base for the sever
 # cut position below.
 DRAWER_DETENT_NUB_X = 24.0
-DRAWER_DETENT_TIP_X = DRAWER_DETENT_NUB_X - DRAWER_DETENT_NUB_BASE_WIDTH / 2 - DETENT_SEVER_CLEARANCE  # ~17.44
-DRAWER_DETENT_ROOT_X = DRAWER_DETENT_NUB_X + DRAWER_DETENT_NUB_TO_ROOT_SPAN                            # 50.0
+DRAWER_DETENT_TIP_X = DRAWER_DETENT_NUB_X - NUB_WIDTH_AT_FLOOR_PLANE / 2 - DETENT_SEVER_CLEARANCE  # ~17.44
+DRAWER_DETENT_ROOT_X = DRAWER_DETENT_NUB_X + DRAWER_DETENT_NUB_TO_ROOT_SPAN                         # 50.0
+
+# Free-tip rise at full DRAWER_DETENT_ENGAGE deflection (F3, issue #20
+# pass-3): same derivation as LID_DETENT_TIP_RISE above, but this
+# mechanism's overhang (nub to free tip) is proportionally larger relative
+# to its span, so tip rise (~2.97) EXCEEDS the old shared 2.5mm
+# DETENT_CLEARANCE -- the beam would bind against the cavity's far wall at
+# ~1.85mm of nub lift, short of the designed 2.2mm engagement. This
+# mechanism therefore needs its OWN, deeper cavity.
+DRAWER_DETENT_FREE_TIP_X = DRAWER_DETENT_TIP_X + DETENT_SEVER_WIDTH / 2   # ~17.94
+DRAWER_DETENT_TIP_OVERHANG = DRAWER_DETENT_NUB_X - DRAWER_DETENT_FREE_TIP_X  # ~6.06
+DRAWER_DETENT_TIP_RISE = _tip_rise(
+    DRAWER_DETENT_ENGAGE, DRAWER_DETENT_TIP_OVERHANG, DRAWER_DETENT_NUB_TO_ROOT_SPAN)  # ~2.97
+DRAWER_DETENT_CAVITY = DRAWER_DETENT_TIP_RISE + 0.5                       # ~3.47
+
+# --- Bottom-panel clearance slot (F2, issue #20 pass-3) ----------------------
+# The drawer's own Bottom panel sits flush across the drawer's FULL exterior
+# footprint, directly beneath the flexure zone, with no cutout there before
+# this fix -- but the nub must reach DRAWER_DETENT_ENGAGE (2.2mm) PAST that
+# panel to do anything useful, and at the flexure's plain zone the panel is
+# solid material in the nub's own swept path (its finger-hole row there is
+# already skipped, per DRAWER_DETENT_PLAIN_LO/HI below, but skipping a HOLE
+# ROW leaves the panel's own solid field untouched -- it doesn't cut a
+# clearance opening). Slot dims (generate_drawers.py cuts one per side wall):
+# - X-length: the nub's WIDEST cross-section (NUB_WIDTH_AT_WALL_PLANE, at
+#   the wall plane -- the widest point the nub sweeps through on its way
+#   down) plus 1mm margin on each end.
+# - Y-span: the wall's own seat zone (0 -> T, the side panel's thickness
+#   footprint) plus 0.5mm inboard margin -- see generate_drawers.py.
+# Hidden under the drawer once assembled (cosmetic underside cutout, same
+# visibility caveat as the shell's own catch holes).
+DRAWER_BOTTOM_SLOT_X_LENGTH = NUB_WIDTH_AT_WALL_PLANE + 2.0   # ~23.12
+DRAWER_BOTTOM_SLOT_Y_SPAN = T + 0.5                           # ~3.675
 
 # The side wall's bottom edge is finger-jointed to the drawer's own Bottom
-# panel along its ENTIRE length except a short PLAIN zone here, sized to
-# contain the flexure's tip-to-root span with margin (a finger-jointed edge
-# can't locally express the nub's protrusion -- see generate_drawers.py). The
-# Bottom panel's matching finger-hole row is split to skip this same zone.
-DRAWER_DETENT_PLAIN_LO = DRAWER_DETENT_TIP_X - 2.0    # ~15.44
-DRAWER_DETENT_PLAIN_HI = DRAWER_DETENT_ROOT_X + 2.0   # 52.0
+# panel along its ENTIRE length except a short PLAIN zone here (a finger-
+# jointed edge can't locally express the nub's protrusion -- see
+# generate_drawers.py). The Bottom panel's matching finger-hole row is split
+# to skip this same zone. The plain zone must be wide enough for BOTH: (a)
+# the flexure beam's own tip-to-root span (with 2mm margin, as before), AND
+# (b) the new clearance slot's X-length (F2, above) with >=3mm margin so the
+# slot doesn't clip the finger-hole row's own teeth where it resumes (same
+# principle CATCH_HOLE_PLAIN_MARGIN applies to the catch holes, below) --
+# whichever requirement is wider wins on each side.
+_DRAWER_BOTTOM_SLOT_MARGIN = 3.0
+_drawer_bottom_slot_lo = DRAWER_DETENT_NUB_X - DRAWER_BOTTOM_SLOT_X_LENGTH / 2
+_drawer_bottom_slot_hi = DRAWER_DETENT_NUB_X + DRAWER_BOTTOM_SLOT_X_LENGTH / 2
+DRAWER_DETENT_PLAIN_LO = min(
+    DRAWER_DETENT_TIP_X - 2.0,
+    _drawer_bottom_slot_lo - _DRAWER_BOTTOM_SLOT_MARGIN,
+)   # ~9.44 (was ~15.44 pre-F2 -- the slot is wider than the beam's own span)
+DRAWER_DETENT_PLAIN_HI = max(
+    DRAWER_DETENT_ROOT_X + 2.0,
+    _drawer_bottom_slot_hi + _DRAWER_BOTTOM_SLOT_MARGIN,
+)   # 52.0 (unchanged -- the beam's root-side margin already covers the slot)
 
 # --- Catch holes (bottom panel for the bottom drawer, shelf for the top
 # drawer): X position derived from existing datums (rear wall plane, the
@@ -298,8 +407,11 @@ DRAWER_FRONT_INNER_FACE_CLOSED_X = BAY_X1 - DRAWER_BAY_GAP - T   # 297.975,
                                    # drawer is fully closed
 CATCH_HOLE_X = DRAWER_FRONT_INNER_FACE_CLOSED_X - DRAWER_DETENT_NUB_X   # ~273.975
 
-# X-length: nub base + ramp clearance, keeping engaged X-slop <= 0.8mm total.
-CATCH_HOLE_X_LENGTH = DRAWER_DETENT_NUB_BASE_WIDTH + 0.8   # ~10.92
+# X-length: nub width AT THE FLOOR PLANE (F4 -- the cross-section that
+# actually threads through this hole, NOT the wider wall-plane cross-
+# section, which never reaches this deep) + ramp clearance, keeping engaged
+# X-slop <= 0.8mm total.
+CATCH_HOLE_X_LENGTH = NUB_WIDTH_AT_FLOOR_PLANE + 0.8   # ~10.92
 
 # Y-width: side thickness + both drawers' full lateral float + margin, so
 # the nub can't miss the hole even at worst-case drawer skew (DESIGN.md

--- a/src/faxbox/config.py
+++ b/src/faxbox/config.py
@@ -137,24 +137,26 @@ ENGRAVE_PIXEL_SIZE = 4.0          # 5x7 pixel font cell size
 ENGRAVE_FONT_SPACING = 2.0        # gap between letters
 ENGRAVE_CENTER = {"x": SHELL_EXT["length"] / 2, "z": 63.5}  # right wall exterior
 
-# --- Retention (iteration 2, issue #20) --------------------------------------
-# Two in-plane laser-cut cantilever spring detents, adapted from Boxes.py's
-# own precedents (boxes/edges.py SlideOnLidSettings/LidRight: spring finger
-# length min(6t, ...), 30 degree tip ramp, catch-hole depth 0.4t; boxes/
-# generators/dinrailbox.py: a cantilever tongue with a nub cut directly into
-# a panel). We adapt the *proportions* of those precedents, not their play
-# values (they assume ~0.3mm clearance; this project's slide clearances are
-# deliberately looser, see SLIDE_CLEARANCE / LID_SLOT_VERTICAL_CLEARANCE
-# above) -- see DESIGN.md's "Retention (iteration 2)" section for the full
-# derivation and coordinates.
+# --- Retention (iteration 3, issue #20 red-team) -----------------------------
+# Two in-plane laser-cut cantilever spring detents. Mechanism A (side-wall
+# lid detent) is unchanged in kinematics from iteration 2, only re-tuned for
+# strain (FIX2). Mechanism B (drawer retention) is a NEW mechanism replacing
+# iteration 2's faceplate detent, which red-team review found geometrically
+# impossible (a Y-Z faceplate can't cam against drawer travel along X --
+# square interference, not a ramp). See DESIGN.md's "Retention (iteration 3)"
+# section for the full derivation, kinematics, and strain numbers.
 #
 # Mechanism A (side walls): a cantilever cut into the wall material just
 # below the lid slot floor, with a ramped nub poking up through the floor
 # into the slot cavity -- the lid's closed position carries a matching
 # edge-open notch that the nub pops into.
-# Mechanism B (drawer faceplates): a cantilever cut near each Y side edge of
-# the faceplate, with a ramped nub poking out sideways past the faceplate's
-# own edge -- it snaps past the rear-wall opening's side edge on close.
+# Mechanism B (drawer sides): a cantilever cut into EACH drawer side wall
+# (an X-Z part -- its plane contains both the travel axis X and the
+# deflection axis Z, so the ramps genuinely cam), nub on the free end
+# protruding DOWN below the side's bottom edge. On insertion the nub cams up
+# over the rear-wall opening's own sill web, rides deflected along the floor
+# (bottom drawer) / shelf (top drawer), and drops into a catch hole cut
+# through that panel at the closed position.
 
 # Nub engagement / interference depths (the two values Ben tunes against the
 # retention coupon before cutting real parts -- see calibration.py).
@@ -162,14 +164,14 @@ LID_DETENT_ENGAGE = 1.5        # nub rise above the lid slot floor (mm); must
                                 # exceed LID_SLOT_VERTICAL_CLEARANCE (0.8) so
                                 # the nub stays engaged when the lid shifts
                                 # within its own vertical play.
-DRAWER_DETENT_PROTRUDE = 1.2   # nub protrusion beyond the faceplate edge
-                                # (mm); 0.45mm interference past the 0.75mm
-                                # FACEPLATE_REVEAL when the faceplate is
-                                # centered in its opening.
+DRAWER_DETENT_ENGAGE = 2.2     # nub protrusion below the drawer side wall's
+                                # bottom edge (mm); exceeds the drawer's
+                                # 1.5mm opening vertical clearance by 0.7mm
+                                # so the nub stays engaged at worst-case
+                                # drawer lift within that clearance.
 
 # Shared cantilever proportions (both mechanisms use the same beam stock;
-# only the nub height/protrusion differs per mechanism above).
-DETENT_BEAM_LENGTH = 18.0       # cantilever length (mm)
+# only the nub height/protrusion and beam span differ per mechanism below).
 DETENT_BEAM_WIDTH = 2.5         # beam cross-section width in the flex
                                 # direction (mm) -- the dimension that bends
 DETENT_ROOT_FILLET = 1.0        # minimum root fillet radius (mm)
@@ -185,20 +187,48 @@ DETENT_NUB_TOP_WIDTH = 2.5      # flat land at the nub's tip (mm); a flat
                                 # top (rather than a knife edge) avoids the
                                 # stress-concentrating point a bare 30 degree
                                 # wedge would leave in cross-grain plywood
+DETENT_SEVER_CLEARANCE = 1.5    # gap kept between a nub's own (ramped) base
+                                # edge and its release/sever cut, so the
+                                # sever cut cannot undercut the nub's own
+                                # base and leave it bridged to the fixed
+                                # material on its outward side (verified
+                                # empirically against the pre-fix wall
+                                # geometry: the ORIGINAL nub-mid-beam design
+                                # already relied on exactly this separation,
+                                # just via a much larger, accidental gap;
+                                # see also DESIGN.md's "Retention" section).
+
+
+def _ramp_run(rise: float) -> float:
+    return rise / math.tan(math.radians(DETENT_RAMP_DEG))
+
+
+def _nub_base_width(rise: float) -> float:
+    return DETENT_NUB_TOP_WIDTH + 2 * _ramp_run(rise)
+
 
 # --- Mechanism A: side-wall lid detent ---------------------------------------
-# Nub centered on the beam (LID_DETENT_X +/- half the beam length); the free
-# (severed) end sits toward the wall's front (mouth) edge, the root end is
-# solid, deeper into the wall -- clear of both the front-edge finger joints
-# (below LID_SLOT_BOTTOM only) and the divider hole line (79.375-82.55).
+# The nub sits at the beam's FREE end (FIX2, red-team pass 2: the previous
+# revision put the nub mid-beam at X=20 with root at X=29, a 9mm root-to-nub
+# span giving eps~6.9% -- above plywood's ~1.5-2% crack threshold). Nub
+# position (LID_DETENT_X) is UNCHANGED so the lid notch position is
+# unaffected; the beam is lengthened and re-anchored so the root sits
+# LID_DETENT_NUB_TO_ROOT_SPAN away from the nub, and the sever cut (the
+# beam's free/tip end) sits DETENT_SEVER_CLEARANCE beyond the nub's own base
+# -- close to the nub (so root-to-nub, the strain-relevant span, is nearly
+# the whole beam) but not so close that the sever cut undercuts the nub's
+# own base and leaves it bridged to the fixed material outward of it.
 LID_DETENT_X = 20.0             # box X, nub center (both walls; the mirror
                                  # convention in shell_generator.py lands
                                  # both walls' nubs at this same real box X)
-LID_DETENT_TIP_X = LID_DETENT_X - DETENT_BEAM_LENGTH / 2   # 11.0, free/severed end
-LID_DETENT_ROOT_X = LID_DETENT_X + DETENT_BEAM_LENGTH / 2  # 29.0, solid anchor end
+LID_DETENT_NUB_TO_ROOT_SPAN = 22.0   # root-to-nub span (mm); eps ~= 1.16%
+                                      # at DETENT_BEAM_WIDTH=2.5,
+                                      # LID_DETENT_ENGAGE=1.5 (see DESIGN.md)
 
-LID_DETENT_RAMP_RUN = LID_DETENT_ENGAGE / math.tan(math.radians(DETENT_RAMP_DEG))
-LID_DETENT_NUB_BASE_WIDTH = DETENT_NUB_TOP_WIDTH + 2 * LID_DETENT_RAMP_RUN  # ~7.7
+LID_DETENT_NUB_BASE_WIDTH = _nub_base_width(LID_DETENT_ENGAGE)   # ~7.70
+
+LID_DETENT_TIP_X = LID_DETENT_X - LID_DETENT_NUB_BASE_WIDTH / 2 - DETENT_SEVER_CLEARANCE  # ~14.65, free/severed end
+LID_DETENT_ROOT_X = LID_DETENT_X + LID_DETENT_NUB_TO_ROOT_SPAN                            # 42.0, solid anchor end
 
 LID_DETENT_NUB_TOP_Z = LID_SLOT_BOTTOM + LID_DETENT_ENGAGE          # 119.525
 LID_DETENT_BEAM_BOTTOM_Z = LID_SLOT_BOTTOM - DETENT_BEAM_WIDTH      # 115.525
@@ -210,26 +240,92 @@ LID_DETENT_CAVITY_BOTTOM_Z = LID_DETENT_BEAM_BOTTOM_Z - DETENT_CLEARANCE  # 113.
 LID_CLOSED_FRONT_X = LID_SLOT_X_END - SLIDING_LID["length"]        # 0.375
 LID_NOTCH_X = LID_DETENT_X - LID_CLOSED_FRONT_X                    # 19.625, lid-local
 LID_NOTCH_WIDTH = LID_DETENT_NUB_BASE_WIDTH + 1.0                  # ~8.7
-LID_NOTCH_DEPTH = 3.0                # >= LID lid-slot engagement (2.425) + margin
+LID_NOTCH_DEPTH = 3.5                # >= LID lid-slot engagement (2.425) + margin;
+                                      # bumped from 3.0 (FIX3, burn consistency):
+                                      # once the notch is drawn shrunk-by-BURN
+                                      # (so its AS-CUT depth matches nominal
+                                      # instead of drifting with BURN), 3.0 left
+                                      # only ~0.075mm of real margin over the
+                                      # 2.925 requirement -- less than BURN
+                                      # itself could erase. 3.5 restores a real
+                                      # margin regardless of BURN's exact value.
 LID_NOTCH_CHAMFER = 1.0              # corner ease at the notch mouth (mm)
 
-# --- Mechanism B: drawer faceplate detent ------------------------------------
-# Nub Z-center at the faceplate's mid-height -- beside (never intersecting)
-# the Y-centered grip slot, which sits ~60mm away in Y. Root end toward the
-# bottom edge, free/severed (tip) end toward the top -- an arbitrary but
-# consistent choice; the grip slot's Y-separation is what actually keeps the
-# two features apart, not the Z split.
-DRAWER_DETENT_Z = FACEPLATE["height"] / 2                          # 26.75
-DRAWER_DETENT_ROOT_Z = DRAWER_DETENT_Z - DETENT_BEAM_LENGTH / 2    # 17.75
-DRAWER_DETENT_TIP_Z = DRAWER_DETENT_Z + DETENT_BEAM_LENGTH / 2     # 35.75
+# --- Mechanism B: drawer side-wall flexure (iteration 3, issue #20) ----------
+# Cut into EACH drawer side wall (Left Side, Right Side -- both, per drawer),
+# near the FRONT (faceplate) end. Convention (this project's own choice,
+# since both ends finger-joint identically to Front/Back and are otherwise
+# symmetric): drawer-local x=0 is the end assembled against the Front panel
+# (the faceplate end); x=BODY_INTERIOR_LENGTH is the Back-panel end. This
+# means each side panel is no longer front/back-symmetric once cut, and must
+# be assembled with its flexure end toward the Front panel -- flagged
+# explicitly here and in DESIGN.md/README since it's a new assembly
+# constraint the pre-iteration-3 parts didn't have.
+#
+# Beam sizing by strain (FIX1): eps = 3*w*delta/(2*L^2), w=DETENT_BEAM_WIDTH,
+# delta=DRAWER_DETENT_ENGAGE. Solving eps<=1.5% for L at w=2.5, delta=2.2
+# gives L >= ~23.45mm; DRAWER_DETENT_NUB_TO_ROOT_SPAN=26 gives eps~=1.22%,
+# a real margin below the ~1.5-2% plywood cracking threshold.
+DRAWER_DETENT_NUB_TO_ROOT_SPAN = 26.0
 
-DRAWER_DETENT_RAMP_RUN = DRAWER_DETENT_PROTRUDE / math.tan(math.radians(DETENT_RAMP_DEG))
-DRAWER_DETENT_NUB_BASE_WIDTH = DETENT_NUB_TOP_WIDTH + 2 * DRAWER_DETENT_RAMP_RUN  # ~6.66
+DRAWER_DETENT_NUB_BASE_WIDTH = _nub_base_width(DRAWER_DETENT_ENGAGE)  # ~10.12
 
-# Faceplate's true drawn footprint, including both nubs (DESIGN.md #9,
-# amended): the outer boundary is drawn offset by DRAWER_DETENT_PROTRUDE so
-# the leftmost nub tip sits at local x=0 (see generate_drawers.py).
-FACEPLATE_DRAWN_WIDTH = FACEPLATE["width"] + 2 * DRAWER_DETENT_PROTRUDE  # 153.3
+# Nub position (drawer-local X, front/faceplate end): far enough from the
+# front finger joints (>=15mm clear, per issue instructions) even after
+# backing out DETENT_SEVER_CLEARANCE + the nub's own half-base for the sever
+# cut position below.
+DRAWER_DETENT_NUB_X = 24.0
+DRAWER_DETENT_TIP_X = DRAWER_DETENT_NUB_X - DRAWER_DETENT_NUB_BASE_WIDTH / 2 - DETENT_SEVER_CLEARANCE  # ~17.44
+DRAWER_DETENT_ROOT_X = DRAWER_DETENT_NUB_X + DRAWER_DETENT_NUB_TO_ROOT_SPAN                            # 50.0
+
+# The side wall's bottom edge is finger-jointed to the drawer's own Bottom
+# panel along its ENTIRE length except a short PLAIN zone here, sized to
+# contain the flexure's tip-to-root span with margin (a finger-jointed edge
+# can't locally express the nub's protrusion -- see generate_drawers.py). The
+# Bottom panel's matching finger-hole row is split to skip this same zone.
+DRAWER_DETENT_PLAIN_LO = DRAWER_DETENT_TIP_X - 2.0    # ~15.44
+DRAWER_DETENT_PLAIN_HI = DRAWER_DETENT_ROOT_X + 2.0   # 52.0
+
+# --- Catch holes (bottom panel for the bottom drawer, shelf for the top
+# drawer): X position derived from existing datums (rear wall plane, the
+# drawer's own closed-position "bay gap" reveal, body length, faceplate
+# thickness) so hole center = nub center at the closed position.
+DRAWER_BAY_GAP = BAY_LENGTH - DRAWER_BODY["length"]   # 0.475, closed-position
+                                                       # reveal (DESIGN.md #9)
+DRAWER_FRONT_INNER_FACE_CLOSED_X = BAY_X1 - DRAWER_BAY_GAP - T   # 297.975,
+                                   # box X of the Front panel's INNER face
+                                   # (interior-facing surface) when the
+                                   # drawer is fully closed
+CATCH_HOLE_X = DRAWER_FRONT_INNER_FACE_CLOSED_X - DRAWER_DETENT_NUB_X   # ~273.975
+
+# X-length: nub base + ramp clearance, keeping engaged X-slop <= 0.8mm total.
+CATCH_HOLE_X_LENGTH = DRAWER_DETENT_NUB_BASE_WIDTH + 0.8   # ~10.92
+
+# Y-width: side thickness + both drawers' full lateral float + margin, so
+# the nub can't miss the hole even at worst-case drawer skew (DESIGN.md
+# derives this from the drawer's own ~4.9mm/side bay float).
+DRAWER_LATERAL_GAP = (INTERIOR_WIDTH - DRAWER_BODY["width"]) / 2   # 4.875, "~4.9mm/side"
+CATCH_HOLE_Y_WIDTH = T + 2 * DRAWER_LATERAL_GAP + 1.0              # ~13.925
+
+# Y centers: box Y of each side wall's mid-thickness when the drawer is
+# laterally centered in the bay (the catch hole's own width, above, covers
+# the full float either side of this nominal center).
+CATCH_HOLE_LEFT_Y = T + DRAWER_LATERAL_GAP + T / 2                              # ~9.6375
+CATCH_HOLE_RIGHT_Y = T + DRAWER_LATERAL_GAP + DRAWER_BODY["width"] - T / 2      # ~155.4625
+
+# Catch holes need real 0.5mm margin at the drawer's WORST-CASE lateral
+# extreme (side wall flush against the bay wall) -- at that extreme, the
+# nub's own footprint already reaches exactly to the bay wall's interior
+# face, so the required margin necessarily pushes the hole a hair PAST that
+# face, into the zone where the bottom panel's/shelf's own finger tabs to
+# that wall would otherwise sit. Rather than let the catch hole silently
+# clip 1-2 finger teeth (verified by rendering: it does), both the bottom
+# panel's and shelf's edges to the LEFT/RIGHT walls carry a short PLAIN
+# zone at the catch hole's own X range (same CompoundEdge technique as the
+# drawer side wall's flexure zone) so there's no tooth there to clip.
+CATCH_HOLE_PLAIN_MARGIN = 3.0
+CATCH_HOLE_X_PLAIN_LO = CATCH_HOLE_X - CATCH_HOLE_X_LENGTH / 2 - CATCH_HOLE_PLAIN_MARGIN
+CATCH_HOLE_X_PLAIN_HI = CATCH_HOLE_X + CATCH_HOLE_X_LENGTH / 2 + CATCH_HOLE_PLAIN_MARGIN
 
 # --- Output ------------------------------------------------------------------
 

--- a/src/faxbox/detent.py
+++ b/src/faxbox/detent.py
@@ -11,14 +11,46 @@ lid-slot code in shell_generator.py mirrors `slot_cx`.
 
 Every shape drawn from these points is closed via the caller doing
 `ctx.move_to(*pts[0]); for p in pts[1:]: ctx.line_to(*p); ctx.close_path();
-ctx.stroke()` -- burn-neutral (raw ctx path, no Boxes.py burn compensation),
-matching this project's existing convention for exact/non-rectangular
-features (calibration.py's kerf-test square, shell_generator.py's pixel-font
-engraving). The two interference values these shapes encode
-(LID_DETENT_ENGAGE, DRAWER_DETENT_PROTRUDE) are explicitly meant to be tuned
-against the retention coupon before cutting real parts, so drawing them
-burn-neutral is a deliberate simplification, not an oversight -- see
-DESIGN.md's "Retention (iteration 2)" section.
+ctx.stroke()`.
+
+BURN (FIX3, iteration-3 red-team): unlike the kerf-test square in
+calibration.py (which must stay burn-NEUTRAL by project rule -- it is
+measuring the real kerf, not compensating for it), these detent shapes are
+real interference features and now carry a `burn: float = 0.0` parameter so
+their drawn geometry can be compensated the same way the rest of the box is,
+via a simple, explicit, documented model (not a byte-for-byte replica of
+Boxes.py's own corner()-arc burn mechanism, which only applies at rounded
+corners and is awkward to replicate for arbitrary ramp angles):
+
+- Boxes.py's own `rectangularHole`/`rectangularWall` only apply burn
+  compensation AT CORNERS (each corner's rounding radius is offset by
+  `burn`) -- long straight runs between corners are drawn at literal
+  nominal size, relying on distant corners to absorb the kerf for the whole
+  edge. These hand-drawn shapes have no such distant corner for their one
+  genuinely LOCAL feature (the nub/notch itself), so ONLY that feature
+  moves; the surrounding flat baseline (u0/u1/z0 away from the nub, an
+  edge's rest_level, a notch's edge_level) stays at literal nominal, same
+  as an ordinary Boxes.py straight run.
+- HOLE shapes (`lid_slot_with_nub_points`, `notch_points`): the nub/notch
+  feature -- a local intrusion of material into the hole, or the hole's own
+  depth/width -- moves FURTHER INTO the hole's interior by `burn`, so its
+  AS-CUT size (measured from the uncompensated, literal baseline) matches
+  the nominal design value.
+- OUTER-BOUNDARY protrusions (`edge_nub_detour`, used where a nub sticks out
+  past a part's own nominal edge): only the peak (nub tip) moves FURTHER
+  OUTWARD (away from the flat baseline) by `burn`, so its AS-CUT protrusion
+  past the (literal, uncompensated) baseline matches nominal.
+
+Because the mating feature on the OTHER part (e.g. a drawer nub's own
+catch hole, cut via plain `rectangularHole` in a different generator/file)
+gets its OWN correct (hole-shrinks) compensation independently, the
+AS-CUT interference between the two independently-compensated parts still
+matches the DESIGN (unburned) interference -- which is the actual point of
+FIX3: pre-iteration-3, the nub geometry was burn-neutral while
+`rectangularHole`-based release cuts nearby WERE compensated, so drawn
+interference silently drifted from as-cut interference as BURN changed;
+now every detent feature (nub, notch, release cut, catch hole) tracks BURN
+consistently.
 """
 
 from __future__ import annotations
@@ -61,6 +93,7 @@ def bump_profile(center: float, base_half: float, top_half: float,
 def lid_slot_with_nub_points(
     u0: float, u1: float, z0: float, z1: float,
     nub_center: float, nub_top_z: float,
+    burn: float = 0.0,
 ) -> list[tuple[float, float]]:
     """Closed polygon for the wall's lid-through-slot hole, with a ramped
     nub bump built into its bottom (z0) boundary at `nub_center`.
@@ -71,7 +104,19 @@ def lid_slot_with_nub_points(
     counterclockwise starting bottom-left; caller mirrors every point's u
     coordinate for the mirrored (left) wall, same convention as the existing
     plain-rectangle slot code.
+
+    `burn` (FIX3): matches Boxes.py's own `rectangularHole` model -- long
+    straight runs (u0/u1/z0 away from the nub, z1) are drawn at literal
+    nominal (Boxes.py itself only compensates AT corners, not mid-edge); the
+    nub is the one genuinely LOCAL, isolated feature with no distant corner
+    to absorb kerf for it, so it alone is drawn taller (nub_top_z moves
+    further from z0, into the hole's interior) by `burn`, so its AS-CUT
+    rise above the (uncompensated, literal) floor matches the nominal
+    LID_DETENT_ENGAGE. See module docstring for the full model.
     """
+    z_sign = 1.0 if z1 >= z0 else -1.0
+    nub_top_z = nub_top_z + z_sign * burn
+
     rise = nub_top_z - z0
     half_base = nub_base_width(rise) / 2
     half_top = DETENT_NUB_TOP_WIDTH / 2
@@ -87,16 +132,28 @@ def lid_slot_with_nub_points(
 
 def edge_nub_detour(
     along_lo: float, along_hi: float, rest_level: float, peak_level: float,
+    burn: float = 0.0,
 ) -> list[tuple[float, float]]:
     """The ramped detour a piece's OUTER boundary takes at one edge nub: a
     small run of points to splice into an otherwise-straight edge, going
     rest_level -> peak_level -> rest_level as `along` increases through
-    [along_lo, along_hi]. Returns (along, across) pairs; the faceplate nub
-    (drawer_detent_outline below) is the one caller today.
+    [along_lo, along_hi]. Returns (along, across) pairs; the drawer side
+    wall's flexure nub (generate_drawers.py) is the caller today.
+
+    `burn` (FIX3): `rest_level` is the same flat baseline as the rest of
+    this edge (compensated, if at all, by the part's own distant corners,
+    not locally); the nub's peak is the local, isolated protrusion with no
+    corner to absorb kerf for it, so only `peak_level` moves further
+    outward (away from rest_level) by `burn`, so its AS-CUT protrusion past
+    the (uncompensated, literal) baseline matches nominal. See module
+    docstring for the full model.
     """
-    rise = abs(peak_level - rest_level)
+    rise = peak_level - rest_level
+    sign = 1.0 if rise >= 0 else -1.0
+    peak_level = peak_level + sign * burn
+
     center = (along_lo + along_hi) / 2
-    half_base = nub_base_width(rise) / 2
+    half_base = nub_base_width(abs(peak_level - rest_level)) / 2
     half_top = DETENT_NUB_TOP_WIDTH / 2
     return bump_profile(center, half_base, half_top, rest_level, peak_level)
 
@@ -148,6 +205,7 @@ def release_cut_rects(
 def notch_points(
     center: float, width: float, depth: float, chamfer: float,
     edge_level: float, inward_sign: float,
+    burn: float = 0.0,
 ) -> list[tuple[float, float]]:
     """Closed polygon for an edge-open notch (used for the lid's mating
     notch): a recess cut INTO a straight edge at `edge_level`, `width` wide
@@ -162,9 +220,16 @@ def notch_points(
     this polygon so its along-edge_level boundary coincides with the part's
     own outer edge, exactly like the existing lid-slot-mouth precedent in
     shell_generator.py -- the laser cuts both lines and the notch opens).
+
+    `burn` (FIX3): `edge_level` is the notch's own mouth, coincident with
+    the lid's true outer edge (compensated, if at all, by the lid's own
+    "eeee" edges elsewhere, not here); the notch's width and depth are the
+    real hole dimensions, so both shrink toward edge_level by `burn` (the
+    same direction Boxes.py's `rectangularHole` shrinks a plain hole), so
+    the AS-CUT notch matches nominal width/depth exactly.
     """
-    half = width / 2
-    floor = edge_level + inward_sign * depth
+    half = width / 2 - burn
+    floor = edge_level + inward_sign * (depth - burn)
     chamfer_floor = edge_level + inward_sign * chamfer
     return [
         (center - half, edge_level),

--- a/src/faxbox/detent.py
+++ b/src/faxbox/detent.py
@@ -1,0 +1,176 @@
+"""Shared point-list geometry for the iteration-2 retention detents (issue
+#20). Pure functions only -- no Boxes.py/cairo calls here, so the shapes are
+independently checkable and reused across shell_generator.py (wall lid
+detent), generate_lids.py (mating notch), generate_drawers.py (faceplate
+detent), and calibration.py (retention coupon).
+
+All functions return points as (x, y) tuples in whatever *local* frame the
+caller already draws in (see each call site) -- callers are responsible for
+any mirroring/offset before/after calling these, exactly like the existing
+lid-slot code in shell_generator.py mirrors `slot_cx`.
+
+Every shape drawn from these points is closed via the caller doing
+`ctx.move_to(*pts[0]); for p in pts[1:]: ctx.line_to(*p); ctx.close_path();
+ctx.stroke()` -- burn-neutral (raw ctx path, no Boxes.py burn compensation),
+matching this project's existing convention for exact/non-rectangular
+features (calibration.py's kerf-test square, shell_generator.py's pixel-font
+engraving). The two interference values these shapes encode
+(LID_DETENT_ENGAGE, DRAWER_DETENT_PROTRUDE) are explicitly meant to be tuned
+against the retention coupon before cutting real parts, so drawing them
+burn-neutral is a deliberate simplification, not an oversight -- see
+DESIGN.md's "Retention (iteration 2)" section.
+"""
+
+from __future__ import annotations
+
+import math
+
+from faxbox.config import DETENT_NUB_TOP_WIDTH, DETENT_RAMP_DEG
+
+
+def ramp_run(rise: float) -> float:
+    """Horizontal run of a DETENT_RAMP_DEG ramp climbing `rise` mm."""
+    return rise / math.tan(math.radians(DETENT_RAMP_DEG))
+
+
+def nub_base_width(rise: float) -> float:
+    return DETENT_NUB_TOP_WIDTH + 2 * ramp_run(rise)
+
+
+def bump_profile(center: float, base_half: float, top_half: float,
+                  base_level: float, top_level: float) -> list[tuple[float, float]]:
+    """Four points tracing a single ramped bump along one axis: base-left,
+    top-left, top-right, base-right. `center`/`base_half`/`top_half` are
+    positions along the "along" axis; `base_level`/`top_level` are the two
+    "across" axis levels (base_level is the surrounding flat plane, top_level
+    is the bump's peak) -- caller decides which tuple element is x vs y (the
+    wall nub bumps in (u, z), the faceplate nub bumps in (y, x); see call
+    sites), by passing `along_first=True/False`.
+
+    Returns points as (along, across) pairs; callers that need (across,
+    along) should swap each tuple themselves.
+    """
+    return [
+        (center - base_half, base_level),
+        (center - top_half, top_level),
+        (center + top_half, top_level),
+        (center + base_half, base_level),
+    ]
+
+
+def lid_slot_with_nub_points(
+    u0: float, u1: float, z0: float, z1: float,
+    nub_center: float, nub_top_z: float,
+) -> list[tuple[float, float]]:
+    """Closed polygon for the wall's lid-through-slot hole, with a ramped
+    nub bump built into its bottom (z0) boundary at `nub_center`.
+
+    (u0, z0)-(u1, z1) is the plain slot rectangle (DESIGN.md #2); the nub
+    rises from z0 to nub_top_z over a small u-range centered on nub_center
+    (base width from LID_DETENT_ENGAGE = nub_top_z - z0). Traced
+    counterclockwise starting bottom-left; caller mirrors every point's u
+    coordinate for the mirrored (left) wall, same convention as the existing
+    plain-rectangle slot code.
+    """
+    rise = nub_top_z - z0
+    half_base = nub_base_width(rise) / 2
+    half_top = DETENT_NUB_TOP_WIDTH / 2
+    bump = bump_profile(nub_center, half_base, half_top, z0, nub_top_z)
+    return [
+        (u0, z0),
+        *bump,
+        (u1, z0),
+        (u1, z1),
+        (u0, z1),
+    ]
+
+
+def edge_nub_detour(
+    along_lo: float, along_hi: float, rest_level: float, peak_level: float,
+) -> list[tuple[float, float]]:
+    """The ramped detour a piece's OUTER boundary takes at one edge nub: a
+    small run of points to splice into an otherwise-straight edge, going
+    rest_level -> peak_level -> rest_level as `along` increases through
+    [along_lo, along_hi]. Returns (along, across) pairs; the faceplate nub
+    (drawer_detent_outline below) is the one caller today.
+    """
+    rise = abs(peak_level - rest_level)
+    center = (along_lo + along_hi) / 2
+    half_base = nub_base_width(rise) / 2
+    half_top = DETENT_NUB_TOP_WIDTH / 2
+    return bump_profile(center, half_base, half_top, rest_level, peak_level)
+
+
+def release_cut_rects(
+    tip: float, root: float, beam_bottom: float, cavity_bottom: float,
+    sever_width: float, floor: float,
+) -> tuple[tuple[float, float, float, float], tuple[float, float, float, float]]:
+    """Two axis-aligned rectangles (cx, cy, width, height) -- matching
+    Boxes.py's rectangularHole(cx, cy, dx, dy) signature -- that together
+    free a cantilever beam on 3 sides while leaving its root (the `root` end)
+    solid:
+
+    - clearance cavity: spans the full beam length [tip, root] at
+      [cavity_bottom, beam_bottom] (below/behind the beam's rest position),
+      giving it room to deflect without bottoming out.
+    - tip-severing slot: a thin `sever_width` slot at the `tip` end, spanning
+      [cavity_bottom, floor] (floor = the beam's flush-with-surroundings top,
+      e.g. the lid slot floor or a faceplate edge), fully parting the beam's
+      tip from the fixed material beyond it. The root end is deliberately
+      left uncut on both rectangles -- see module docstring.
+
+    `tip`/`root` and `beam_bottom`/`cavity_bottom`/`floor` may each be either
+    sign of "low to high" -- the wall (along=X increasing away from the
+    mouth, across=Z DEcreasing away from the slot floor) and the faceplate
+    (along=Z increasing away from the root, across=drawn-x INcreasing away
+    from a left edge but DEcreasing away from a right edge) use opposite
+    conventions, so every pair below is min/max-normalized rather than
+    assumed ordered.
+    """
+    lo, hi = min(tip, root), max(tip, root)
+    cavity_cx = (lo + hi) / 2
+    cavity_w = hi - lo
+    across_lo, across_hi = min(beam_bottom, cavity_bottom), max(beam_bottom, cavity_bottom)
+    cavity_cy = (across_lo + across_hi) / 2
+    cavity_h = across_hi - across_lo
+
+    sever_cx = tip
+    sever_lo, sever_hi = min(cavity_bottom, floor), max(cavity_bottom, floor)
+    sever_cy = (sever_lo + sever_hi) / 2
+    sever_h = sever_hi - sever_lo
+
+    return (
+        (cavity_cx, cavity_cy, cavity_w, cavity_h),
+        (sever_cx, sever_cy, sever_width, sever_h),
+    )
+
+
+def notch_points(
+    center: float, width: float, depth: float, chamfer: float,
+    edge_level: float, inward_sign: float,
+) -> list[tuple[float, float]]:
+    """Closed polygon for an edge-open notch (used for the lid's mating
+    notch): a recess cut INTO a straight edge at `edge_level`, `width` wide
+    (centered on `center`), `depth` deep, with the two mouth corners eased by
+    a `chamfer` x `chamfer` 45-degree cut instead of a sharp corner.
+
+    `inward_sign` is +1 if the part's interior is at coordinates greater than
+    edge_level (recessing increases the across-axis value) or -1 if the
+    interior is at lesser values -- i.e. which way "deeper" points.
+
+    Returns (along, across) pairs, open toward the edge (the caller draws
+    this polygon so its along-edge_level boundary coincides with the part's
+    own outer edge, exactly like the existing lid-slot-mouth precedent in
+    shell_generator.py -- the laser cuts both lines and the notch opens).
+    """
+    half = width / 2
+    floor = edge_level + inward_sign * depth
+    chamfer_floor = edge_level + inward_sign * chamfer
+    return [
+        (center - half, edge_level),
+        (center - half, chamfer_floor),
+        (center - half + chamfer, floor),
+        (center + half - chamfer, floor),
+        (center + half, chamfer_floor),
+        (center + half, edge_level),
+    ]

--- a/src/faxbox/generate_drawers.py
+++ b/src/faxbox/generate_drawers.py
@@ -36,13 +36,15 @@ from faxbox.config import (
     DETENT_ROOT_FILLET,
     DETENT_SEVER_WIDTH,
     DRAWER_BODY,
-    DRAWER_DETENT_PROTRUDE,
-    DRAWER_DETENT_ROOT_Z,
-    DRAWER_DETENT_TIP_Z,
+    DRAWER_DETENT_ENGAGE,
+    DRAWER_DETENT_NUB_X,
+    DRAWER_DETENT_PLAIN_HI,
+    DRAWER_DETENT_PLAIN_LO,
+    DRAWER_DETENT_ROOT_X,
+    DRAWER_DETENT_TIP_X,
     DRAWER_GRIP_SLOT,
     ENGRAVE_COLOR,
     FACEPLATE,
-    FACEPLATE_DRAWN_WIDTH,
     MATERIAL_THICKNESS,
     OUTPUT_DIR,
 )
@@ -50,12 +52,45 @@ from faxbox.detent import edge_nub_detour, release_cut_rects
 
 T = MATERIAL_THICKNESS
 
-# Body interior (DESIGN.md #9: "Body interior: 142.65 x 211.65 x 50.325").
+# Body interior (DESIGN.md #9: "Body interior: 142.65 x 212.25 x 50.325").
 # Width/length lose a thickness on each of their two jointed (vertical
 # corner) edges; height only loses the bottom -- the top is open.
-BODY_INTERIOR_LENGTH = DRAWER_BODY["length"] - 2 * T   # 211.65, X
+BODY_INTERIOR_LENGTH = DRAWER_BODY["length"] - 2 * T   # 212.25, X
 BODY_INTERIOR_WIDTH = DRAWER_BODY["width"] - 2 * T     # 142.65, Y
 BODY_INTERIOR_HEIGHT = DRAWER_BODY["height"] - T       # 50.325, Z (floor -> open top)
+
+
+class _DrawerFlexureNubEdge(edges.Edge):
+    """A straight edge (drop-in for Boxes.py's plain "e") that additionally
+    draws a single ramped, DOWNWARD-protruding flexure nub at a fixed
+    position along its own length.
+
+    Used as the middle segment of a CompoundEdge standing in for the drawer
+    side wall's normally fully finger-jointed bottom edge, over the
+    flexure's plain zone (mechanism B, iteration 3, issue #20 red-team):
+    Boxes.py's edge classes draw one continuous run with no way to inject a
+    local protrusion (the same limitation the removed iteration-2 faceplate
+    detent hit), so this is a purpose-built Edge subclass instead of a
+    callback -- it participates in the same finger-joint-length-matching
+    CompoundEdge convention already used elsewhere in this project
+    (shell_generator.py's front-edge and top-panel CompoundEdges).
+    """
+
+    def __init__(self, boxes, nub_center_local: float, peak_depth: float) -> None:
+        super().__init__(boxes, None)
+        self.nub_center_local = nub_center_local
+        self.peak_depth = peak_depth
+
+    def __call__(self, length, **kw):
+        detour = edge_nub_detour(
+            self.nub_center_local - 1.0, self.nub_center_local + 1.0,
+            0.0, -self.peak_depth, burn=self.burn,
+        )
+        self.ctx.move_to(0, 0)
+        for x, y in detour:
+            self.ctx.line_to(x, y)
+        self.ctx.line_to(length, 0)
+        self.ctx.translate(*self.ctx.get_current_point())
 
 GRIP_SLOT_W = DRAWER_GRIP_SLOT["width"]
 GRIP_SLOT_H = DRAWER_GRIP_SLOT["height"]
@@ -82,16 +117,6 @@ class DrawerBox(Boxes):
     def _grip_slot_center_y(self, panel_height: float) -> float:
         slot_top = panel_height - GRIP_SLOT_TOP_BELOW_EDGE
         return slot_top - GRIP_SLOT_H / 2
-
-    def _draw_closed_polygon(self, points: list[tuple[float, float]]) -> None:
-        """Stroke a closed polygon -- see faxbox.detent module docstring;
-        duplicated per-generator like generate_lids.py's copy since Boxes.py
-        generators don't share a common mixin base."""
-        self.ctx.move_to(*points[0])
-        for pt in points[1:]:
-            self.ctx.line_to(*pt)
-        self.ctx.line_to(*points[0])
-        self.ctx.stroke()
 
     def _draw_engraved_rect_outline(self, cx: float, cy: float, width: float, height: float) -> None:
         """Red-engraved rectangle outline, drawn as 4 disjoint line segments
@@ -154,10 +179,63 @@ class DrawerBox(Boxes):
     def _build_side(self, label: str) -> None:
         """Side wall: BODY_INTERIOR_LENGTH (local X = box X) x
         BODY_INTERIOR_HEIGHT (local Y = box Z). Front/back-mating edges
-        finger-joint (both ends), bottom finger-joints the Bottom panel, top
-        open."""
+        finger-joint (both ends), top open.
+
+        Bottom edge: finger-jointed to the Bottom panel EXCEPT a short
+        PLAIN zone (DRAWER_DETENT_PLAIN_LO -> DRAWER_DETENT_PLAIN_HI) near
+        the FRONT (x=0, faceplate) end, carrying a cantilever spring-detent
+        flexure (mechanism B, iteration 3, issue #20 red-team replacement
+        for the geometrically-impossible faceplate detent -- see DESIGN.md
+        "Retention"). Convention (this project's own choice; both ends
+        finger-joint identically otherwise, so nothing else distinguishes
+        them): local x=0 mates the Front panel (the faceplate end); this is
+        a NEW assembly constraint -- both side panels must go in with their
+        flexure end toward Front, not Back. A finger-jointed edge can't
+        locally express the nub's protrusion (same reason the old faceplate
+        needed a hand-drawn boundary), so the plain zone uses a purpose-
+        built Edge (_DrawerFlexureNubEdge) via CompoundEdge instead of a
+        plain 'e' -- the Bottom panel's matching finger-hole row is split to
+        skip this same X-range (see _build_bottom)."""
+        seg1_len = DRAWER_DETENT_PLAIN_LO
+        seg2_len = DRAWER_DETENT_PLAIN_HI - DRAWER_DETENT_PLAIN_LO
+        seg3_len = BODY_INTERIOR_LENGTH - DRAWER_DETENT_PLAIN_HI
+        nub_center_local = DRAWER_DETENT_NUB_X - DRAWER_DETENT_PLAIN_LO
+        # The plain zone's local y=0 is the wall's NOMINAL (pre-tab) bottom
+        # reference; the "f" edges either side of it already protrude T
+        # beyond that (their finger tabs reach the drawer's TRUE exterior
+        # bottom). DRAWER_DETENT_ENGAGE is defined relative to that true
+        # exterior bottom (DESIGN.md), so the nub's drawn depth from y=0 is
+        # T + DRAWER_DETENT_ENGAGE, not DRAWER_DETENT_ENGAGE alone -- else
+        # the nub falls short of even the neighboring tabs' own reach.
+        nub_edge = _DrawerFlexureNubEdge(self, nub_center_local, T + DRAWER_DETENT_ENGAGE)
+        bottom_edge = edges.CompoundEdge(
+            self, ["f", nub_edge, "f"], [seg1_len, seg2_len, seg3_len])
+
+        def callback() -> None:
+            # Cantilever release cut: frees the beam on 3 sides (a clearance
+            # cavity above it, into the panel's own solid material, and a
+            # severing slot at its free/tip end) while leaving the root end
+            # (deeper into the wall, toward the Back panel) solid -- same
+            # L-shape logic as the wall's lid detent (faxbox.detent.
+            # release_cut_rects), just transposed: "along" is X, "across"
+            # is local Y, "floor" is the plain zone's own baseline (local
+            # y=0), and the beam sits ABOVE it (local y increasing, into
+            # the panel) rather than below, since the nub protrudes DOWN
+            # past y=0 while the panel's own bulk is above it.
+            beam_top = DETENT_BEAM_WIDTH
+            cavity_top = DETENT_BEAM_WIDTH + DETENT_CLEARANCE
+            cavity, sever = release_cut_rects(
+                tip=DRAWER_DETENT_TIP_X, root=DRAWER_DETENT_ROOT_X,
+                beam_bottom=beam_top, cavity_bottom=cavity_top,
+                sever_width=DETENT_SEVER_WIDTH, floor=0.0,
+            )
+            self.rectangularHole(*cavity, r=DETENT_ROOT_FILLET)
+            self.rectangularHole(*sever, r=DETENT_ROOT_FILLET)
+
         self.rectangularWall(
-            BODY_INTERIOR_LENGTH, BODY_INTERIOR_HEIGHT, "ffef",
+            BODY_INTERIOR_LENGTH, BODY_INTERIOR_HEIGHT,
+            [bottom_edge, self.edges["f"], self.edges["e"], self.edges["f"]],
+            callback=[callback, None, None, None],
             move="right", label=label,
         )
 
@@ -166,18 +244,29 @@ class DrawerBox(Boxes):
         it sits flush with the walls' true outside faces, not inset between
         them, and its own edges stay plain (captive: DESIGN.md "walls'
         bottom edges may extend downward" while the bottom does not). The
-        4 finger-hole rows below receive the walls' downward-protruding
+        finger-hole rows below receive the walls' downward-protruding
         bottom-edge tabs, one per wall, each row's length matching that
-        wall's own interior nominal so the finger pitch lines up."""
+        wall's own interior nominal so the finger pitch lines up.
+
+        The left/right (side-wall) rows are each SPLIT into two segments
+        skipping DRAWER_DETENT_PLAIN_LO -> DRAWER_DETENT_PLAIN_HI, matching
+        the side walls' own CompoundEdge plain zone there (mechanism B) --
+        without this split, that row would carry finger holes with no
+        tab to plug them (the side wall has no tab in that zone either)."""
 
         def callback() -> None:
             length, width = DRAWER_BODY["length"], DRAWER_BODY["width"]
             # Front/back rows: vertical, near the X=0 / X=length edges.
             self.fingerHolesAt(T / 2, T, BODY_INTERIOR_WIDTH, angle=90)
             self.fingerHolesAt(length - T / 2, T, BODY_INTERIOR_WIDTH, angle=90)
-            # Left/right rows: horizontal, near the Y=0 / Y=width edges.
-            self.fingerHolesAt(T, T / 2, BODY_INTERIOR_LENGTH, angle=0)
-            self.fingerHolesAt(T, width - T / 2, BODY_INTERIOR_LENGTH, angle=0)
+            # Left/right rows: horizontal, near the Y=0 / Y=width edges,
+            # split around the flexure's plain zone (both side walls carry
+            # the SAME zone, so both rows split the same way).
+            seg2_start = T + DRAWER_DETENT_PLAIN_HI
+            seg2_len = BODY_INTERIOR_LENGTH - DRAWER_DETENT_PLAIN_HI
+            for y in (T / 2, width - T / 2):
+                self.fingerHolesAt(T, y, DRAWER_DETENT_PLAIN_LO, angle=0)
+                self.fingerHolesAt(seg2_start, y, seg2_len, angle=0)
 
         self.rectangularWall(
             DRAWER_BODY["length"], DRAWER_BODY["width"], "eeee",
@@ -187,94 +276,32 @@ class DrawerBox(Boxes):
 
     def _build_faceplate(self) -> None:
         """Faceplate: FACEPLATE width x height (DESIGN.md #9), plain edges
-        (glued, not finger-jointed), plus a cantilever spring detent near
-        EACH Y side edge (retention iteration 2, issue #20): a ramped nub
-        protrudes DRAWER_DETENT_PROTRUDE beyond the nominal edge on both
-        sides, so it can snap past the rear-wall opening's side edge on
-        close. Grip slot and the glue-up registration outline are unchanged
-        in size, just re-centered for the drawing offset below.
+        (glued, not finger-jointed). Grip slot aligned with the body
+        Front's, plus a red-engraved registration outline of the body's
+        front cross-section (DRAWER_BODY width x height, centered).
 
-        Boxes.py's rectangularWall can't inject a local protrusion into a
-        plain "e" edge's path (an edge class draws one continuous straight
-        run for its whole length), so the outer boundary is hand-drawn here
-        instead -- see faxbox.detent's module docstring. This deliberately
-        makes the Faceplate's drawn/measured footprint
-        FACEPLATE_DRAWN_WIDTH (150.9 + 2*DRAWER_DETENT_PROTRUDE) rather than
-        the plain FACEPLATE["width"] -- see DESIGN.md "Retention (iteration
-        2)" and the flagged test_faceplate_blank_size deviation in
-        tests/test_svg_geometry.py for why that's an intentional, minimal,
-        and unavoidable consequence of this being a REAL protruding
-        interference feature (there's no way to add real retention without
-        the physical part becoming physically bigger at the nub).
-        """
-        offset = DRAWER_DETENT_PROTRUDE  # true drawn x=0 is the LEFT nub's tip
-        width, height = FACEPLATE["width"], FACEPLATE["height"]
+        Reverted to the exact v1 (pre-iteration-2) blank (issue #20
+        red-team FIX1): the iteration-2 faceplate detent was geometrically
+        impossible (the faceplate is a Y-Z plate; the drawer travels along
+        X, normal to that plate, so a Z-ramped nub can never be swept by the
+        drawer's own motion -- it would only ever meet the rear-wall opening
+        as a square 0.45mm interference, not a cam). Retention now lives
+        entirely in the drawer SIDE walls instead -- see _build_side and
+        DESIGN.md's "Retention" section."""
 
-        def body_x(x: float) -> float:
-            return x + offset
-
-        left_rest, right_rest = body_x(0.0), body_x(width)
-        left_peak, right_peak = left_rest - DRAWER_DETENT_PROTRUDE, right_rest + DRAWER_DETENT_PROTRUDE
-
-        # edge_nub_detour returns (along=Z, across=drawn-x) pairs in
-        # increasing-Z order; swap to (x, y) for the polygon point list.
-        right_detour = [(x, y) for y, x in edge_nub_detour(
-            DRAWER_DETENT_ROOT_Z, DRAWER_DETENT_TIP_Z, right_rest, right_peak)]
-        left_detour = [(x, y) for y, x in edge_nub_detour(
-            DRAWER_DETENT_ROOT_Z, DRAWER_DETENT_TIP_Z, left_rest, left_peak)]
-
-        outline = [
-            (left_rest, 0.0),
-            (right_rest, 0.0),
-            (right_rest, DRAWER_DETENT_ROOT_Z),
-            *right_detour,
-            (right_rest, height),
-            (left_rest, height),
-            (left_rest, DRAWER_DETENT_TIP_Z),
-            *reversed(left_detour),
-        ]
-
-        # Bypass rectangularWall's automatic straight-edge drawing: its "e"
-        # edge class draws one continuous run for the whole edge length with
-        # no way to inject the nub detour above, and calling it anyway (even
-        # sized to FACEPLATE_DRAWN_WIDTH) would additionally stroke a plain
-        # rectangle overlapping/conflicting with the hand-drawn outline. Use
-        # the same before/after self.move() bookkeeping rectangularWall uses
-        # internally (its own sanctioned public API for this exact purpose,
-        # per its docstring) so this piece still lands correctly in the
-        # move="right" row of parts, without also drawing the plain edges.
-        if self.move(FACEPLATE_DRAWN_WIDTH, height, "right", before=True):
-            return
-        self.moveTo(0, 0)
-
-        self.set_source_color(CUT_COLOR)
-        self._draw_closed_polygon(outline)
-
-        cy = self._grip_slot_center_y(height)
-        self.rectangularHole(body_x(width / 2), cy, GRIP_SLOT_W, GRIP_SLOT_H, r=GRIP_SLOT_R)
-        self._draw_engraved_rect_outline(
-            body_x(width / 2), height / 2,
-            DRAWER_BODY["width"], DRAWER_BODY["height"],
-        )
-
-        # Cantilever release cuts (both sides): free the beam on 3 sides
-        # while leaving its root end solid, same L-shape logic as the wall's
-        # lid detent (faxbox.detent.release_cut_rects), just transposed --
-        # "along" here is Z (root/tip), "across" is drawn-x, so the returned
-        # (cx, cy, dx, dy) tuples need their x/y swapped before calling
-        # rectangularHole(x, y, dx, dy).
-        for edge_rest, sign in ((left_rest, 1.0), (right_rest, -1.0)):
-            beam_bottom = edge_rest + sign * DETENT_BEAM_WIDTH
-            cavity_bottom = edge_rest + sign * (DETENT_BEAM_WIDTH + DETENT_CLEARANCE)
-            cavity, sever = release_cut_rects(
-                tip=DRAWER_DETENT_TIP_Z, root=DRAWER_DETENT_ROOT_Z,
-                beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
-                sever_width=DETENT_SEVER_WIDTH, floor=edge_rest,
+        def callback() -> None:
+            cy = self._grip_slot_center_y(FACEPLATE["height"])
+            self.rectangularHole(FACEPLATE["width"] / 2, cy, GRIP_SLOT_W, GRIP_SLOT_H, r=GRIP_SLOT_R)
+            self._draw_engraved_rect_outline(
+                FACEPLATE["width"] / 2, FACEPLATE["height"] / 2,
+                DRAWER_BODY["width"], DRAWER_BODY["height"],
             )
-            for cx, cy, dx, dy in (cavity, sever):
-                self.rectangularHole(cy, cx, dy, dx, r=DETENT_ROOT_FILLET)
 
-        self.move(FACEPLATE_DRAWN_WIDTH, height, "right", label="Faceplate")
+        self.rectangularWall(
+            FACEPLATE["width"], FACEPLATE["height"], "eeee",
+            callback=[callback, None, None, None],
+            move="right", label="Faceplate",
+        )
 
     def render(self) -> None:
         """Render all 6 pieces, laid out in a single row (move='right'

--- a/src/faxbox/generate_drawers.py
+++ b/src/faxbox/generate_drawers.py
@@ -32,10 +32,12 @@ from faxbox.config import (
     BURN,
     CUT_COLOR,
     DETENT_BEAM_WIDTH,
-    DETENT_CLEARANCE,
     DETENT_ROOT_FILLET,
     DETENT_SEVER_WIDTH,
     DRAWER_BODY,
+    DRAWER_BOTTOM_SLOT_X_LENGTH,
+    DRAWER_BOTTOM_SLOT_Y_SPAN,
+    DRAWER_DETENT_CAVITY,
     DRAWER_DETENT_ENGAGE,
     DRAWER_DETENT_NUB_X,
     DRAWER_DETENT_PLAIN_HI,
@@ -223,7 +225,7 @@ class DrawerBox(Boxes):
             # the panel) rather than below, since the nub protrudes DOWN
             # past y=0 while the panel's own bulk is above it.
             beam_top = DETENT_BEAM_WIDTH
-            cavity_top = DETENT_BEAM_WIDTH + DETENT_CLEARANCE
+            cavity_top = DETENT_BEAM_WIDTH + DRAWER_DETENT_CAVITY
             cavity, sever = release_cut_rects(
                 tip=DRAWER_DETENT_TIP_X, root=DRAWER_DETENT_ROOT_X,
                 beam_bottom=beam_top, cavity_bottom=cavity_top,
@@ -252,7 +254,24 @@ class DrawerBox(Boxes):
         skipping DRAWER_DETENT_PLAIN_LO -> DRAWER_DETENT_PLAIN_HI, matching
         the side walls' own CompoundEdge plain zone there (mechanism B) --
         without this split, that row would carry finger holes with no
-        tab to plug them (the side wall has no tab in that zone either)."""
+        tab to plug them (the side wall has no tab in that zone either).
+
+        Nub clearance slot (F2, issue #20 red-team pass-3): the flexure nub
+        protrudes T + DRAWER_DETENT_ENGAGE below the wall's own local y=0,
+        i.e. DRAWER_DETENT_ENGAGE past this panel's own bottom face -- but
+        this panel spans the drawer's FULL exterior footprint, so without a
+        cutout here, the nub's own swept material has nowhere to go (it
+        would have to occupy the same space as this panel's own solid
+        plywood). One rectangular clearance hole per side wall, centered on
+        that wall's flexure nub (box X = T + DRAWER_DETENT_NUB_X, the same
+        offset the finger-hole row split above already accounts for), sized
+        to the nub's WIDEST cross-section (at the wall plane, where it's
+        still flush with the wall's bulk) plus margin -- see
+        DRAWER_BOTTOM_SLOT_X_LENGTH / DRAWER_BOTTOM_SLOT_Y_SPAN in
+        config.py. Y-span starts exactly at each side's true edge (0 or
+        width) since that's where the wall itself sits -- no material is
+        lost outboard of the wall's own seat, only inboard by the slot's
+        margin. Hidden under the drawer once assembled."""
 
         def callback() -> None:
             length, width = DRAWER_BODY["length"], DRAWER_BODY["width"]
@@ -267,6 +286,17 @@ class DrawerBox(Boxes):
             for y in (T / 2, width - T / 2):
                 self.fingerHolesAt(T, y, DRAWER_DETENT_PLAIN_LO, angle=0)
                 self.fingerHolesAt(seg2_start, y, seg2_len, angle=0)
+
+            # Nub clearance slot, one per side wall (F2, above).
+            slot_cx = T + DRAWER_DETENT_NUB_X
+            for slot_cy in (
+                DRAWER_BOTTOM_SLOT_Y_SPAN / 2,
+                width - DRAWER_BOTTOM_SLOT_Y_SPAN / 2,
+            ):
+                self.rectangularHole(
+                    slot_cx, slot_cy,
+                    DRAWER_BOTTOM_SLOT_X_LENGTH, DRAWER_BOTTOM_SLOT_Y_SPAN, r=0,
+                )
 
         self.rectangularWall(
             DRAWER_BODY["length"], DRAWER_BODY["width"], "eeee",

--- a/src/faxbox/generate_drawers.py
+++ b/src/faxbox/generate_drawers.py
@@ -31,13 +31,22 @@ from faxbox.config import (
     FINGER_PLAY_RELATIVE,
     BURN,
     CUT_COLOR,
+    DETENT_BEAM_WIDTH,
+    DETENT_CLEARANCE,
+    DETENT_ROOT_FILLET,
+    DETENT_SEVER_WIDTH,
     DRAWER_BODY,
+    DRAWER_DETENT_PROTRUDE,
+    DRAWER_DETENT_ROOT_Z,
+    DRAWER_DETENT_TIP_Z,
     DRAWER_GRIP_SLOT,
     ENGRAVE_COLOR,
     FACEPLATE,
+    FACEPLATE_DRAWN_WIDTH,
     MATERIAL_THICKNESS,
     OUTPUT_DIR,
 )
+from faxbox.detent import edge_nub_detour, release_cut_rects
 
 T = MATERIAL_THICKNESS
 
@@ -73,6 +82,16 @@ class DrawerBox(Boxes):
     def _grip_slot_center_y(self, panel_height: float) -> float:
         slot_top = panel_height - GRIP_SLOT_TOP_BELOW_EDGE
         return slot_top - GRIP_SLOT_H / 2
+
+    def _draw_closed_polygon(self, points: list[tuple[float, float]]) -> None:
+        """Stroke a closed polygon -- see faxbox.detent module docstring;
+        duplicated per-generator like generate_lids.py's copy since Boxes.py
+        generators don't share a common mixin base."""
+        self.ctx.move_to(*points[0])
+        for pt in points[1:]:
+            self.ctx.line_to(*pt)
+        self.ctx.line_to(*points[0])
+        self.ctx.stroke()
 
     def _draw_engraved_rect_outline(self, cx: float, cy: float, width: float, height: float) -> None:
         """Red-engraved rectangle outline, drawn as 4 disjoint line segments
@@ -168,23 +187,94 @@ class DrawerBox(Boxes):
 
     def _build_faceplate(self) -> None:
         """Faceplate: FACEPLATE width x height (DESIGN.md #9), plain edges
-        (glued, not finger-jointed). Grip slot aligned with the body
-        Front's, plus a red-engraved registration outline of the body's
-        front cross-section (DRAWER_BODY width x height, centered)."""
+        (glued, not finger-jointed), plus a cantilever spring detent near
+        EACH Y side edge (retention iteration 2, issue #20): a ramped nub
+        protrudes DRAWER_DETENT_PROTRUDE beyond the nominal edge on both
+        sides, so it can snap past the rear-wall opening's side edge on
+        close. Grip slot and the glue-up registration outline are unchanged
+        in size, just re-centered for the drawing offset below.
 
-        def callback() -> None:
-            cy = self._grip_slot_center_y(FACEPLATE["height"])
-            self.rectangularHole(FACEPLATE["width"] / 2, cy, GRIP_SLOT_W, GRIP_SLOT_H, r=GRIP_SLOT_R)
-            self._draw_engraved_rect_outline(
-                FACEPLATE["width"] / 2, FACEPLATE["height"] / 2,
-                DRAWER_BODY["width"], DRAWER_BODY["height"],
-            )
+        Boxes.py's rectangularWall can't inject a local protrusion into a
+        plain "e" edge's path (an edge class draws one continuous straight
+        run for its whole length), so the outer boundary is hand-drawn here
+        instead -- see faxbox.detent's module docstring. This deliberately
+        makes the Faceplate's drawn/measured footprint
+        FACEPLATE_DRAWN_WIDTH (150.9 + 2*DRAWER_DETENT_PROTRUDE) rather than
+        the plain FACEPLATE["width"] -- see DESIGN.md "Retention (iteration
+        2)" and the flagged test_faceplate_blank_size deviation in
+        tests/test_svg_geometry.py for why that's an intentional, minimal,
+        and unavoidable consequence of this being a REAL protruding
+        interference feature (there's no way to add real retention without
+        the physical part becoming physically bigger at the nub).
+        """
+        offset = DRAWER_DETENT_PROTRUDE  # true drawn x=0 is the LEFT nub's tip
+        width, height = FACEPLATE["width"], FACEPLATE["height"]
 
-        self.rectangularWall(
-            FACEPLATE["width"], FACEPLATE["height"], "eeee",
-            callback=[callback, None, None, None],
-            move="right", label="Faceplate",
+        def body_x(x: float) -> float:
+            return x + offset
+
+        left_rest, right_rest = body_x(0.0), body_x(width)
+        left_peak, right_peak = left_rest - DRAWER_DETENT_PROTRUDE, right_rest + DRAWER_DETENT_PROTRUDE
+
+        # edge_nub_detour returns (along=Z, across=drawn-x) pairs in
+        # increasing-Z order; swap to (x, y) for the polygon point list.
+        right_detour = [(x, y) for y, x in edge_nub_detour(
+            DRAWER_DETENT_ROOT_Z, DRAWER_DETENT_TIP_Z, right_rest, right_peak)]
+        left_detour = [(x, y) for y, x in edge_nub_detour(
+            DRAWER_DETENT_ROOT_Z, DRAWER_DETENT_TIP_Z, left_rest, left_peak)]
+
+        outline = [
+            (left_rest, 0.0),
+            (right_rest, 0.0),
+            (right_rest, DRAWER_DETENT_ROOT_Z),
+            *right_detour,
+            (right_rest, height),
+            (left_rest, height),
+            (left_rest, DRAWER_DETENT_TIP_Z),
+            *reversed(left_detour),
+        ]
+
+        # Bypass rectangularWall's automatic straight-edge drawing: its "e"
+        # edge class draws one continuous run for the whole edge length with
+        # no way to inject the nub detour above, and calling it anyway (even
+        # sized to FACEPLATE_DRAWN_WIDTH) would additionally stroke a plain
+        # rectangle overlapping/conflicting with the hand-drawn outline. Use
+        # the same before/after self.move() bookkeeping rectangularWall uses
+        # internally (its own sanctioned public API for this exact purpose,
+        # per its docstring) so this piece still lands correctly in the
+        # move="right" row of parts, without also drawing the plain edges.
+        if self.move(FACEPLATE_DRAWN_WIDTH, height, "right", before=True):
+            return
+        self.moveTo(0, 0)
+
+        self.set_source_color(CUT_COLOR)
+        self._draw_closed_polygon(outline)
+
+        cy = self._grip_slot_center_y(height)
+        self.rectangularHole(body_x(width / 2), cy, GRIP_SLOT_W, GRIP_SLOT_H, r=GRIP_SLOT_R)
+        self._draw_engraved_rect_outline(
+            body_x(width / 2), height / 2,
+            DRAWER_BODY["width"], DRAWER_BODY["height"],
         )
+
+        # Cantilever release cuts (both sides): free the beam on 3 sides
+        # while leaving its root end solid, same L-shape logic as the wall's
+        # lid detent (faxbox.detent.release_cut_rects), just transposed --
+        # "along" here is Z (root/tip), "across" is drawn-x, so the returned
+        # (cx, cy, dx, dy) tuples need their x/y swapped before calling
+        # rectangularHole(x, y, dx, dy).
+        for edge_rest, sign in ((left_rest, 1.0), (right_rest, -1.0)):
+            beam_bottom = edge_rest + sign * DETENT_BEAM_WIDTH
+            cavity_bottom = edge_rest + sign * (DETENT_BEAM_WIDTH + DETENT_CLEARANCE)
+            cavity, sever = release_cut_rects(
+                tip=DRAWER_DETENT_TIP_Z, root=DRAWER_DETENT_ROOT_Z,
+                beam_bottom=beam_bottom, cavity_bottom=cavity_bottom,
+                sever_width=DETENT_SEVER_WIDTH, floor=edge_rest,
+            )
+            for cx, cy, dx, dy in (cavity, sever):
+                self.rectangularHole(cy, cx, dy, dx, r=DETENT_ROOT_FILLET)
+
+        self.move(FACEPLATE_DRAWN_WIDTH, height, "right", label="Faceplate")
 
     def render(self) -> None:
         """Render all 6 pieces, laid out in a single row (move='right'

--- a/src/faxbox/generate_lids.py
+++ b/src/faxbox/generate_lids.py
@@ -73,11 +73,13 @@ class LidGenerator(Boxes):
             bottom_edge = notch_points(
                 center=LID_NOTCH_X, width=LID_NOTCH_WIDTH, depth=LID_NOTCH_DEPTH,
                 chamfer=LID_NOTCH_CHAMFER, edge_level=0.0, inward_sign=1.0,
+                burn=self.burn,
             )
             self._draw_closed_polygon(bottom_edge)
             top_edge = notch_points(
                 center=LID_NOTCH_X, width=LID_NOTCH_WIDTH, depth=LID_NOTCH_DEPTH,
                 chamfer=LID_NOTCH_CHAMFER, edge_level=width, inward_sign=-1.0,
+                burn=self.burn,
             )
             self._draw_closed_polygon(top_edge)
 

--- a/src/faxbox/generate_lids.py
+++ b/src/faxbox/generate_lids.py
@@ -20,10 +20,15 @@ from faxbox.config import (
     BURN,
     CUT_COLOR,
     LID_GRIP_SLOT,
+    LID_NOTCH_CHAMFER,
+    LID_NOTCH_DEPTH,
+    LID_NOTCH_WIDTH,
+    LID_NOTCH_X,
     MATERIAL_THICKNESS,
     OUTPUT_DIR,
     SLIDING_LID,
 )
+from faxbox.detent import notch_points
 
 
 class LidGenerator(Boxes):
@@ -32,6 +37,18 @@ class LidGenerator(Boxes):
     def __init__(self) -> None:
         Boxes.__init__(self)
         self.addSettingsArgs(edges.FingerJointSettings)
+
+    def _draw_closed_polygon(self, points: list[tuple[float, float]]) -> None:
+        """Stroke a closed polygon -- see faxbox.detent module docstring for
+        why this is burn-neutral raw ctx, matching the wall nub/notch
+        convention (shell_generator.py's _draw_closed_polygon, duplicated
+        here rather than shared since Boxes.py generators are independent
+        Boxes subclasses with no common base to hang a mixin off cleanly)."""
+        self.ctx.move_to(*points[0])
+        for pt in points[1:]:
+            self.ctx.line_to(*pt)
+        self.ctx.line_to(*points[0])
+        self.ctx.stroke()
 
     def render(self) -> None:
         """Render the sliding lid piece."""
@@ -46,6 +63,23 @@ class LidGenerator(Boxes):
                 slot["center_from_front"], width / 2,
                 slot["width"], slot["height"], r=slot["radius"],
             )
+            # Mating notches for the side-wall lid detent nubs (retention
+            # iteration 2, issue #20): edge-open recesses on BOTH long
+            # edges, at the X position that aligns with each wall's nub
+            # when the lid is closed (DESIGN.md "Retention (iteration 2)").
+            # Edge-open the same way the wall's lid-slot mouth is: the
+            # polygon's own edge-level boundary coincides with the lid's
+            # real edge, so both lines get cut and the notch opens through.
+            bottom_edge = notch_points(
+                center=LID_NOTCH_X, width=LID_NOTCH_WIDTH, depth=LID_NOTCH_DEPTH,
+                chamfer=LID_NOTCH_CHAMFER, edge_level=0.0, inward_sign=1.0,
+            )
+            self._draw_closed_polygon(bottom_edge)
+            top_edge = notch_points(
+                center=LID_NOTCH_X, width=LID_NOTCH_WIDTH, depth=LID_NOTCH_DEPTH,
+                chamfer=LID_NOTCH_CHAMFER, edge_level=width, inward_sign=-1.0,
+            )
+            self._draw_closed_polygon(top_edge)
 
         self.rectangularWall(
             length, width, "eeee",

--- a/src/faxbox/shell_generator.py
+++ b/src/faxbox/shell_generator.py
@@ -29,6 +29,8 @@ from faxbox.config import (
     BOTTOM_OPENING_Z1,
     BURN,
     CUT_COLOR,
+    DETENT_ROOT_FILLET,
+    DETENT_SEVER_WIDTH,
     DIVIDER_HEIGHT,
     DIVIDER_X0,
     DIVIDER_X1,
@@ -42,8 +44,15 @@ from faxbox.config import (
     FRONT_WALL_TOP,
     INTERIOR_LENGTH,
     INTERIOR_WIDTH,
+    LID_DETENT_BEAM_BOTTOM_Z,
+    LID_DETENT_CAVITY_BOTTOM_Z,
+    LID_DETENT_NUB_TOP_Z,
+    LID_DETENT_ROOT_X,
+    LID_DETENT_TIP_X,
+    LID_DETENT_X,
     LID_SLOT_BOTTOM,
     LID_SLOT_HEIGHT,
+    LID_SLOT_TOP,
     LID_SLOT_X_END,
     MATERIAL_THICKNESS,
     OPENING_HEIGHT,
@@ -55,6 +64,7 @@ from faxbox.config import (
     TOP_PANEL_HOLE_Z,
     WALL_HEIGHT,
 )
+from faxbox.detent import lid_slot_with_nub_points, release_cut_rects
 
 T = MATERIAL_THICKNESS
 
@@ -144,6 +154,17 @@ class OuterShell(Boxes):
                 self.ctx.stroke()
         return pixel_size * 5 + ENGRAVE_FONT_SPACING
 
+    def _draw_closed_polygon(self, points: list[tuple[float, float]]) -> None:
+        """Stroke a closed polygon from a plain (x, y) point list -- burn-
+        neutral raw ctx path (see detent.py's module docstring for why),
+        used for the retention nub/notch shapes that rectangularHole's plain
+        rectangle can't express."""
+        self.ctx.move_to(*points[0])
+        for pt in points[1:]:
+            self.ctx.line_to(*pt)
+        self.ctx.line_to(*points[0])  # close (Boxes.py's Context has no close_path)
+        self.ctx.stroke()
+
     def draw_pixel_text(self, text: str, x: float, y: float, pixel_size: float = ENGRAVE_PIXEL_SIZE) -> None:
         """Draw text using the pixel font in the engraving (red) color."""
         self.set_source_color(ENGRAVE_COLOR)
@@ -228,13 +249,40 @@ class OuterShell(Boxes):
 
             # Lid through-slot: closed hole whose front boundary coincides
             # with the blank's front edge -- both lines get cut, opening the
-            # mouth (DESIGN.md #2).
+            # mouth (DESIGN.md #2). Its bottom boundary carries a ramped nub
+            # bump (retention iteration 2, issue #20, DESIGN.md "Retention
+            # (iteration 2)") -- the nub is the tip of a cantilever cut into
+            # the material below the slot floor (see the release cut below);
+            # both features are defined in unmirrored local-u = box X - T,
+            # then every vertex is mirrored for the left wall so both walls'
+            # nubs land at the same real box X (same convention as slot_cx).
             slot_length = LID_SLOT_X_END - T
-            slot_cx = slot_length / 2
-            slot_cz = LID_SLOT_BOTTOM + LID_SLOT_HEIGHT / 2
+            u_nub = LID_DETENT_X - T
+            points = lid_slot_with_nub_points(
+                u0=0, u1=slot_length, z0=LID_SLOT_BOTTOM, z1=LID_SLOT_TOP,
+                nub_center=u_nub, nub_top_z=LID_DETENT_NUB_TOP_Z,
+            )
             if mirror:
-                slot_cx = mirror_point(slot_cx)
-            self.rectangularHole(slot_cx, slot_cz, slot_length, LID_SLOT_HEIGHT, r=0)
+                points = [(mirror_point(u), z) for u, z in points]
+            self._draw_closed_polygon(points)
+
+            # Cantilever release cut: frees the beam on 3 sides (clearance
+            # cavity below it, a severing slot at its free/tip end) while
+            # leaving the root end (deeper into the wall) solid, so the
+            # tongue carrying the nub above can flex down under the lid's
+            # leading edge and spring back up once past it.
+            u_tip = LID_DETENT_TIP_X - T
+            u_root = LID_DETENT_ROOT_X - T
+            if mirror:
+                u_tip, u_root = mirror_point(u_tip), mirror_point(u_root)
+            cavity, sever = release_cut_rects(
+                tip=u_tip, root=u_root,
+                beam_bottom=LID_DETENT_BEAM_BOTTOM_Z,
+                cavity_bottom=LID_DETENT_CAVITY_BOTTOM_Z,
+                sever_width=DETENT_SEVER_WIDTH, floor=LID_SLOT_BOTTOM,
+            )
+            self.rectangularHole(*cavity, r=DETENT_ROOT_FILLET)
+            self.rectangularHole(*sever, r=DETENT_ROOT_FILLET)
 
             # Divider finger-hole line (vertical).
             divider_x = DIVIDER_MID_LOCAL_X

--- a/src/faxbox/shell_generator.py
+++ b/src/faxbox/shell_generator.py
@@ -28,6 +28,13 @@ from faxbox.config import (
     BOTTOM_OPENING_Z0,
     BOTTOM_OPENING_Z1,
     BURN,
+    CATCH_HOLE_LEFT_Y,
+    CATCH_HOLE_RIGHT_Y,
+    CATCH_HOLE_X,
+    CATCH_HOLE_X_LENGTH,
+    CATCH_HOLE_X_PLAIN_HI,
+    CATCH_HOLE_X_PLAIN_LO,
+    CATCH_HOLE_Y_WIDTH,
     CUT_COLOR,
     DETENT_ROOT_FILLET,
     DETENT_SEVER_WIDTH,
@@ -190,15 +197,42 @@ class OuterShell(Boxes):
     # -- pieces ---------------------------------------------------------
 
     def _build_bottom(self) -> None:
-        """Bottom panel: INTERIOR_LENGTH x INTERIOR_WIDTH, 'f' all around,
-        plus a fingerHolesAt line receiving the divider's bottom-edge
-        fingers (DESIGN.md #1)."""
+        """Bottom panel: INTERIOR_LENGTH x INTERIOR_WIDTH, 'f' all around
+        EXCEPT a short PLAIN zone on the two side-wall-facing edges at the
+        catch holes' own X range, plus a fingerHolesAt line receiving the
+        divider's bottom-edge fingers (DESIGN.md #1), plus two CATCH HOLES
+        for the bottom drawer's side-wall flexure nubs (mechanism B,
+        iteration 3, issue #20 -- DESIGN.md "Retention"). Visible from the
+        box underside when empty (cosmetic, accepted per that section).
+
+        The plain zone exists because the catch holes need real margin at
+        the drawer's worst-case lateral extreme, where the nub's own
+        footprint already reaches exactly to the bay wall's interior face
+        -- without it, the hole clips 1-2 of this edge's own finger teeth
+        (verified by rendering) instead of missing them cleanly. See
+        CATCH_HOLE_X_PLAIN_LO/HI in config.py."""
+
+        # Edge index travel (same as _build_top_panel's own note): bottom
+        # (index0) runs local x 0->max, top (index2) runs back max->0, so
+        # the compound segment order flips for index2 -- otherwise its
+        # plain zone lands mirrored to the wrong X range (caught by
+        # test_shelf_teeth_align_with_wall_shelf_rows's drawer-adjacent
+        # analog on this panel during this fix).
+        plain_lo = CATCH_HOLE_X_PLAIN_LO - T
+        plain_hi = CATCH_HOLE_X_PLAIN_HI - T
+        seg1, seg2, seg3 = plain_lo, plain_hi - plain_lo, INTERIOR_LENGTH - plain_hi
+        side_edge_left = edges.CompoundEdge(self, ["f", "e", "f"], [seg1, seg2, seg3])
+        side_edge_right = edges.CompoundEdge(self, ["f", "e", "f"], [seg3, seg2, seg1])
 
         def callback() -> None:
             self.fingerHolesAt(DIVIDER_MID_LOCAL_X, 0, INTERIOR_WIDTH, angle=90)
+            catch_x = CATCH_HOLE_X - T
+            for catch_y in (CATCH_HOLE_LEFT_Y - T, CATCH_HOLE_RIGHT_Y - T):
+                self.rectangularHole(catch_x, catch_y, CATCH_HOLE_X_LENGTH, CATCH_HOLE_Y_WIDTH, r=0)
 
         self.rectangularWall(
-            INTERIOR_LENGTH, INTERIOR_WIDTH, "ffff",
+            INTERIOR_LENGTH, INTERIOR_WIDTH,
+            [side_edge_left, self.edges["f"], side_edge_right, self.edges["f"]],
             callback=[callback, None, None, None],
             move="right", label="Bottom",
         )
@@ -244,8 +278,20 @@ class OuterShell(Boxes):
             right_edge = front_edge_bottom_to_top
 
         def callback() -> None:
-            # Bottom-panel finger-hole line (straight edge, hole line only).
-            self.fingerHolesAt(0, T / 2, INTERIOR_LENGTH, angle=0)
+            # Bottom-panel finger-hole line (straight edge, hole line only),
+            # split around the catch-hole plain zone (mechanism B, iteration
+            # 3, issue #20) so this row doesn't carry holes with no tab to
+            # plug them, matching the Bottom panel's own CompoundEdge plain
+            # zone there (see shell_generator._build_bottom). Local x = box
+            # X - T when unmirrored; the plain zone's two X bounds are each
+            # individually mirror_point'd (then reordered) for the left
+            # wall, same convention as the divider/lid-slot single points.
+            plain_lo = CATCH_HOLE_X_PLAIN_LO - T
+            plain_hi = CATCH_HOLE_X_PLAIN_HI - T
+            if mirror:
+                plain_lo, plain_hi = mirror_point(plain_hi), mirror_point(plain_lo)
+            self.fingerHolesAt(0, T / 2, plain_lo, angle=0)
+            self.fingerHolesAt(plain_hi, T / 2, INTERIOR_LENGTH - plain_hi, angle=0)
 
             # Lid through-slot: closed hole whose front boundary coincides
             # with the blank's front edge -- both lines get cut, opening the
@@ -261,6 +307,7 @@ class OuterShell(Boxes):
             points = lid_slot_with_nub_points(
                 u0=0, u1=slot_length, z0=LID_SLOT_BOTTOM, z1=LID_SLOT_TOP,
                 nub_center=u_nub, nub_top_z=LID_DETENT_NUB_TOP_Z,
+                burn=self.burn,
             )
             if mirror:
                 points = [(mirror_point(u), z) for u, z in points]
@@ -290,11 +337,26 @@ class OuterShell(Boxes):
                 divider_x = mirror_point(divider_x)
             self.fingerHolesAt(divider_x, FLOOR_TOP, DIVIDER_HEIGHT, angle=90)
 
-            # Shelf finger-hole line (horizontal).
+            # Shelf finger-hole line (horizontal), split around the catch-
+            # hole plain zone (mechanism B, iteration 3, issue #20) to
+            # match the Shelf's own CompoundEdge plain zone there (see
+            # shell_generator._build_shelf). Row-relative coordinates (0 at
+            # shelf_x0): unmirrored, row-relative-x runs the same direction
+            # as box X (offset by BAY_X0), so the zone is simply the plain
+            # bounds shifted by BAY_X0; mirrored, row-relative-x runs
+            # OPPOSITE box X (row-relative 0 = box X BAY_X1, per the
+            # mirror_start convention), so the zone is BAY_X1 minus each
+            # bound, reordered.
             shelf_x0 = BAY_X0 - T
-            if mirror:
+            if not mirror:
+                zone_lo_rel = CATCH_HOLE_X_PLAIN_LO - BAY_X0
+                zone_hi_rel = CATCH_HOLE_X_PLAIN_HI - BAY_X0
+            else:
                 shelf_x0 = mirror_start(shelf_x0, BAY_LENGTH)
-            self.fingerHolesAt(shelf_x0, SHELF_MID_Z, BAY_LENGTH, angle=0)
+                zone_lo_rel = BAY_X1 - CATCH_HOLE_X_PLAIN_HI
+                zone_hi_rel = BAY_X1 - CATCH_HOLE_X_PLAIN_LO
+            self.fingerHolesAt(shelf_x0, SHELF_MID_Z, zone_lo_rel, angle=0)
+            self.fingerHolesAt(shelf_x0 + zone_hi_rel, SHELF_MID_Z, BAY_LENGTH - zone_hi_rel, angle=0)
 
             # Top-panel finger-hole line (horizontal, just below the top
             # edge; panel finger tips end flush with the exterior face).
@@ -366,10 +428,32 @@ class OuterShell(Boxes):
 
     def _build_shelf(self) -> None:
         """Horizontal shelf: BAY_LENGTH (local X = box X - BAY_X0) x
-        INTERIOR_WIDTH (local Y = box Y), side edges into the side walls,
-        front edge into the divider, rear edge plain (DESIGN.md #6)."""
+        INTERIOR_WIDTH (local Y = box Y), side edges into the side walls
+        EXCEPT a short PLAIN zone at the catch holes' own X range (see
+        _build_bottom for why), front edge into the divider, rear edge
+        plain (DESIGN.md #6), plus two CATCH HOLES for the top drawer's
+        side-wall flexure nubs (mechanism B, iteration 3, issue #20 --
+        DESIGN.md "Retention") -- the shelf is this drawer's own "floor",
+        same role the bottom panel plays for the bottom drawer."""
+
+        # Edge index travel: bottom (index0) runs local x 0->max, top
+        # (index2) runs back max->0 (same note as _build_bottom/
+        # _build_top_panel), so index2's compound segment order is reversed.
+        plain_lo = CATCH_HOLE_X_PLAIN_LO - BAY_X0
+        plain_hi = CATCH_HOLE_X_PLAIN_HI - BAY_X0
+        seg1, seg2, seg3 = plain_lo, plain_hi - plain_lo, BAY_LENGTH - plain_hi
+        side_edge_left = edges.CompoundEdge(self, ["f", "e", "f"], [seg1, seg2, seg3])
+        side_edge_right = edges.CompoundEdge(self, ["f", "e", "f"], [seg3, seg2, seg1])
+
+        def callback() -> None:
+            catch_x = CATCH_HOLE_X - BAY_X0
+            for catch_y in (CATCH_HOLE_LEFT_Y - T, CATCH_HOLE_RIGHT_Y - T):
+                self.rectangularHole(catch_x, catch_y, CATCH_HOLE_X_LENGTH, CATCH_HOLE_Y_WIDTH, r=0)
+
         self.rectangularWall(
-            BAY_LENGTH, INTERIOR_WIDTH, ["f", "e", "f", "f"],
+            BAY_LENGTH, INTERIOR_WIDTH,
+            [side_edge_left, self.edges["e"], side_edge_right, self.edges["f"]],
+            callback=[callback, None, None, None],
             move="right", label="Horizontal Shelf",
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,25 @@ SRC_DIR = str(REPO_ROOT / "src")
 # everywhere, not just in the fixture below.
 os.environ["PYTHONPATH"] = SRC_DIR + os.pathsep + os.environ.get("PYTHONPATH", "")
 
+# ... but os.environ["PYTHONPATH"] only affects subprocesses spawned from here
+# on (pass-2 red-team CRITICAL finding): the pytest process ITSELF has already
+# resolved `faxbox` at interpreter startup via the editable install's .pth
+# file, which in a worktree checkout points at the ORIGINAL repo's src/, not
+# this one. Every in-process `import faxbox...` in the test modules --
+# including config.py, which most of test_retention.py etc. read directly
+# without ever going through a subprocess -- would therefore still silently
+# read the WRONG tree's code, regardless of the env var above.
+#
+# Fix: put THIS checkout's src/ at the front of sys.path directly, before any
+# test module (or this conftest) has imported faxbox. conftest.py is always
+# imported by pytest before it collects/imports test modules in this
+# directory, so doing this here -- at conftest import time, prior to any
+# `import faxbox` anywhere in the session -- guarantees in-process imports
+# resolve to this checkout too. Insert at index 0 so it wins over the
+# editable install's .pth entry regardless of where that entry lands.
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
 # The three generator entry points (issue #16 verification procedure). Run in
 # this order via `sys.executable -m <module>` -- same as a human would from
 # the README -- so the fixture exercises exactly what ships, not an in-process

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 Tests import faxbox.config directly; DESIGN.md is the geometry authority.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,26 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = str(REPO_ROOT / "src")
+
+# Force THIS repo's src/ onto every subprocess's import path (issue #20
+# iteration-3 red-team FIX4): faxbox is normally installed editable
+# (`pip install -e .`), which points at wherever the venv was created, not
+# necessarily this checkout. In a git WORKTREE (a second checkout of the
+# same repo on a different branch/path), that editable install still
+# resolves to the ORIGINAL checkout's src/ -- meaning `python -m
+# faxbox.<generator>` subprocess calls (here AND in test_layout.py /
+# test_retention.py's own regeneration fixtures) would silently regenerate
+# SVGs from the WRONG tree's code, and every test in the suite would then
+# measure geometry the diff under review never touched.
+#
+# Mutating os.environ directly (rather than building a local env dict some
+# call sites would have to remember to pass) makes this a session-wide fix:
+# every `subprocess.run(...)` anywhere in this test session that does NOT
+# pass its own `env=` (which is all of them, in this suite) inherits
+# os.environ by default, so THIS checkout's src/ takes precedence
+# everywhere, not just in the fixture below.
+os.environ["PYTHONPATH"] = SRC_DIR + os.pathsep + os.environ.get("PYTHONPATH", "")
 
 # The three generator entry points (issue #16 verification procedure). Run in
 # this order via `sys.executable -m <module>` -- same as a human would from

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -486,6 +486,84 @@ def test_drawer_side_strain_within_crack_threshold(side):
     )
 
 
+def _measured_tip_rise(engage: float, overhang: float, span: float) -> float:
+    """Local (test-only) re-implementation of config._tip_rise's formula --
+    deliberately NOT imported from faxbox.config, so this test's oracle is
+    independent of the helper that sizes DRAWER_DETENT_CAVITY (issue #20
+    pass-3 F3: comparing a measurement to the value that produced it can't
+    catch a wrong value)."""
+    return engage * (1 + 3 * overhang / (2 * span))
+
+
+@pytest.mark.parametrize("side", DRAWER_SIDES)
+def test_drawer_side_cavity_clears_measured_tip_rise(side):
+    """F3 (issue #20 pass-3, MAJOR): the drawer flexure's free tip rises
+    MORE than the nub's own designed engagement, because the severed free
+    tip overhangs past the nub's own load point toward the beam's free end
+    -- a beam-deflection effect the previous revision's shared
+    DETENT_CLEARANCE (2.5mm, sized only to the nub's own rise) did not
+    account for: computed tip rise ~2.97mm > that 2.5mm cavity, so the beam
+    would BIND against the cavity's far wall at ~1.85mm of nub lift,
+    short of the designed 2.2mm engagement (test_drawer_side_strain_
+    within_crack_threshold, above, only checks bending STRAIN -- it does
+    not catch a too-shallow cavity, since the beam can be well within its
+    crack threshold and still physically bind).
+
+    Computes the tip rise ENTIRELY from measured SVG dimensions (nub
+    position, root position, severed free-tip position, nub's own rise)
+    via a LOCAL copy of the tip-rise formula (not importing DRAWER_DETENT_
+    CAVITY / DRAWER_DETENT_TIP_RISE from config), then asserts the beam's
+    own measured clearance cavity is deep enough that it won't bind --
+    catches e.g. a reversion of DRAWER_DETENT_CAVITY back to the old
+    shared 2.5mm value.
+    """
+    piece = _piece(DRAWER_SVG, side)
+    bump = _nub_bump_geometry(piece.outer.d)
+    nub_cx = (bump["top_left"] + bump["top_right"]) / 2
+
+    cavity_candidates = [
+        h for h in _blue_holes(piece)
+        if abs((h.bbox.xmin + h.bbox.xmax) / 2 - nub_cx) <= 30.0
+        and h.bbox.width >= 15.0
+    ]
+    assert len(cavity_candidates) == 1, (
+        f"{side}: expected exactly 1 wide (cavity) release-cut hole, found {len(cavity_candidates)}"
+    )
+    cavity = cavity_candidates[0].bbox
+    root_x = cavity.xmax if abs(cavity.xmax - nub_cx) > abs(cavity.xmin - nub_cx) else cavity.xmin
+    span = abs(root_x - nub_cx)
+    assert span > 5.0, f"{side}: measured root-to-nub span implausibly small ({span:.2f})"
+
+    sever_candidates = [
+        h for h in _blue_holes(piece)
+        if abs((h.bbox.xmin + h.bbox.xmax) / 2 - nub_cx) <= 30.0
+        and h.bbox.width <= 3.0
+    ]
+    assert len(sever_candidates) == 1, (
+        f"{side}: expected exactly 1 narrow (sever) release-cut hole, found {len(sever_candidates)}"
+    )
+    sever = sever_candidates[0].bbox
+    # The beam's TRUE free tip is the sever cut's edge CLOSER to the root --
+    # the opposite edge disconnects into non-load-bearing material (see
+    # config._tip_rise's docstring / DESIGN.md's "Retention" section).
+    free_tip_x = sever.xmax if abs(sever.xmax - root_x) < abs(sever.xmin - root_x) else sever.xmin
+    overhang = abs(nub_cx - free_tip_x)
+    assert overhang > 0.5, f"{side}: measured tip overhang implausibly small ({overhang:.2f})"
+
+    tab_reach_y = _deepest_y_excluding_nub(piece.outer.d, bump["top_y"])
+    engage = bump["top_y"] - tab_reach_y
+    assert engage > 0
+
+    computed_tip_rise = _measured_tip_rise(engage, overhang, span)
+    available_clearance = cavity.height
+    assert available_clearance >= computed_tip_rise - 0.1, (
+        f"{side}: measured cavity clearance ({available_clearance:.2f}mm) is less "
+        f"than the computed free-tip rise ({computed_tip_rise:.2f}mm at engage="
+        f"{engage:.2f}, overhang={overhang:.2f}, span={span:.2f}) -- the beam "
+        f"would BIND against the cavity's far wall before reaching full engagement"
+    )
+
+
 # =============================================================================
 # 4. Faceplate BLANK INVARIANT: back to the exact v1 plain rectangle
 # =============================================================================
@@ -592,6 +670,104 @@ def test_catch_holes_at_same_box_x_on_both_panels():
         assert abs(bx - sx) <= 0.6, (
             f"bottom-panel catch hole at box X={bx:.2f} does not match shelf's "
             f"catch hole at box X={sx:.2f} -- both drawers close to the same position"
+        )
+
+
+def test_catch_hole_registers_with_nub_via_independent_datums():
+    """F4 (issue #20 pass-3, CRITICAL): catch-hole <-> nub registration was
+    previously untested end-to-end -- the pass-2 critic's mutation
+    `CATCH_HOLE_X += 5.0` stayed green against every other test in this
+    file, because nothing computed the nub's closed-position box-X
+    INDEPENDENTLY of the very formula (DRAWER_FRONT_INNER_FACE_CLOSED_X -
+    DRAWER_DETENT_NUB_X) that drew the catch hole -- comparing a
+    measurement to the config value that produced it can't catch a wrong
+    value, only a crashed generator.
+
+    Datums, matching DESIGN.md's own registration derivation, but each
+    combined from a MEASUREMENT (not a config echo of CATCH_HOLE_X or
+    DRAWER_DETENT_NUB_X, the two values a registration bug would touch)
+    plus stable, unrelated bay-fit constants (BAY_X1 "rear-wall plane",
+    BAY_LENGTH -- shell/bay geometry with nothing to do with retention
+    specifically):
+    - drawer body length: MEASURED from drawer.svg's own "Bottom" piece (a
+      plain, un-jointed "eeee" rectangle -- generate_drawers.py -- so its
+      bbox is the body's true external footprint with zero tab-protrusion
+      ambiguity, unlike the finger-jointed side panels the nub itself is
+      cut into).
+    - flexure X-position within the side (the faceplate-recess-relative
+      "nub position" datum): MEASURED as that SAME Bottom piece's own
+      nub-clearance slot center (F2 fix, generate_drawers.py) -- also a
+      plain, un-jointed rectangularHole, anchored to the exact same
+      unambiguous local x=0 as the body-length measurement above. The slot
+      is deliberately centered on the nub, so its measured center is a
+      legitimate, precise stand-in for the nub's own X position that
+      avoids the jointed side panel's up-to-T tab-position ambiguity.
+
+    Asserts the SHELL's catch hole X-span CONTAINS the independently-
+    computed nub X-span (at the nub's floor-plane cross-section --
+    NUB_WIDTH_AT_FLOOR_PLANE, the fixed physical width that actually
+    threads through the hole, not a mutation target) with <= 1.0mm total
+    slop.
+    """
+    bottom_drawer = _piece(DRAWER_SVG, "bottom")
+    body_length = bottom_drawer.bbox.width  # measured, NOT c.DRAWER_BODY["length"]
+
+    slot_candidates = [
+        h for h in _blue_holes(bottom_drawer)
+        if h.bbox.width > h.bbox.height
+        and 15.0 <= h.bbox.width <= 35.0
+        and 2.0 <= h.bbox.height <= 6.0
+    ]
+    assert len(slot_candidates) == 2, (
+        f"expected 2 nub-clearance slots (F2) on the drawer's Bottom panel, "
+        f"found {len(slot_candidates)} -- can't independently locate the nub "
+        f"without them"
+    )
+
+    measured_bay_gap = c.BAY_LENGTH - body_length  # independent stand-in for
+                                                    # DRAWER_BAY_GAP, using the
+                                                    # MEASURED body length
+
+    nub_box_xs = []
+    for slot in slot_candidates:
+        slot_center_x_local = (slot.bbox.xmin + slot.bbox.xmax) / 2 - bottom_drawer.bbox.xmin
+        flexure_x_from_front_inner_face = slot_center_x_local - T
+        nub_box_xs.append(c.BAY_X1 - measured_bay_gap - T - flexure_x_from_front_inner_face)
+
+    assert max(nub_box_xs) - min(nub_box_xs) <= 0.6, (
+        f"the two side walls' flexure slots don't land at the same box X: {nub_box_xs}"
+    )
+
+    bottom_shell = _piece(SHELL_SVG, "bottom")
+    min_span = T + 2 * DRAWER_LATERAL_FLOAT_PER_SIDE
+    catch_holes = [
+        h for h in _blue_holes(bottom_shell)
+        if h.bbox.width < h.bbox.height and 8.0 <= h.bbox.width <= 16.0
+        and h.bbox.height >= min_span
+    ]
+    assert len(catch_holes) == 2, f"expected 2 catch holes on the bottom panel, found {len(catch_holes)}"
+
+    half_floor_width = c.NUB_WIDTH_AT_FLOOR_PLANE / 2
+
+    for nub_box_x in nub_box_xs:
+        nub_lo = nub_box_x - half_floor_width
+        nub_hi = nub_box_x + half_floor_width
+        # Both catch holes should sit at the same box X (only Y differs);
+        # pick the nearest one so a symmetric X-shift of both is still caught.
+        best = min(
+            catch_holes,
+            key=lambda h: abs((h.bbox.xmin + h.bbox.xmax) / 2 - bottom_shell.bbox.xmin - nub_box_x),
+        )
+        catch_lo = best.bbox.xmin - bottom_shell.bbox.xmin
+        catch_hi = best.bbox.xmax - bottom_shell.bbox.xmin
+        lo_slack = max(0.0, catch_lo - nub_lo)
+        hi_slack = max(0.0, nub_hi - catch_hi)
+        total_slop = lo_slack + hi_slack
+        assert total_slop <= 1.0, (
+            f"catch hole X-span [{catch_lo:.2f}, {catch_hi:.2f}] does not contain the "
+            f"independently-computed nub X-span [{nub_lo:.2f}, {nub_hi:.2f}] (combined "
+            f"slop {total_slop:.2f}mm > 1.0mm) -- registration broken (e.g. mutation "
+            f"CATCH_HOLE_X += 5.0 must fail this)"
         )
 
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,12 +1,23 @@
-"""Retention (iteration 2, issue #20) tests: positional/mating assertions on
-the two spring-detent mechanisms, parsing the actual SVGs the same way
-test_svg_geometry.py does (never trusting a predefined mental model of the
-geometry -- see that file's module docstring on why size-only checks aren't
-enough). Policy unchanged from test_svg_geometry.py: never weaken a test to
-pass; existing tests are untouched except the two flagged, documented,
-minimal deviations in test_svg_geometry.py (test_faceplate_blank_size and
-test_edge_polarity_literals_present) that are an unavoidable consequence of
-the faceplate nub becoming a real, physically larger, protruding piece.
+"""Retention (iteration 3, issue #20 red-team) tests: parse the ACTUAL SVGs
+the same way test_svg_geometry.py does (never trusting a predefined mental
+model of the geometry). Rewritten wholesale for the iteration-3 mechanisms
+(mutation testing on the iteration-2 version of this file let 3 of 8 fatal
+mutations through -- see the mutation-gate table in the PR description).
+
+Rules this rewrite follows throughout:
+- EXISTENCE first: every check parses the real SVG and asserts the feature
+  (nub, ramp, release cut, catch hole) actually exists on the actual part
+  before measuring it -- a part drawn as a plain rectangle must fail, not
+  vacuously pass a conditional.
+- FIXED PHYSICAL BOUNDS, not config echoes: assertions compare a measured
+  SVG quantity against a LITERAL (0.8, 1.5, 2.0, 4.9, ...) or an
+  independently-derived quantity, never the same config constant the
+  generator itself drew from -- comparing a measurement to the value that
+  produced it can't catch a wrong value, only a crashed generator.
+- BLANK INVARIANTS: the faceplate is back to its exact v1 blank (no nub);
+  test_svg_geometry.py's restored test_faceplate_blank_size covers the
+  overall dimension, this file adds a shape-level check (no ramp/diagonal
+  segments at all) that a size-only check can't express.
 """
 
 from __future__ import annotations
@@ -34,6 +45,16 @@ LIDS_SVG = OUTPUT_DIR / "lids.svg"
 T = c.MATERIAL_THICKNESS
 LID_SLOT_LENGTH = c.LID_SLOT_X_END - T
 WALL_SIDES = [("right wall", False), ("left wall", True)]
+DRAWER_SIDES = ["left side", "right side"]
+
+# Physical literals this file measures against (never a config echo of the
+# same value the generator used to draw the feature):
+LID_VERTICAL_PLAY = 0.8          # DESIGN.md: LID_SLOT_VERTICAL_CLEARANCE
+DRAWER_OPENING_VERTICAL_PLAY = 1.5  # DESIGN.md: drawer body <-> opening height clearance
+DRAWER_LATERAL_FLOAT_PER_SIDE = 4.9  # DESIGN.md: "~4.9mm/side by design"
+MAX_STRAIN_PCT = 2.0             # plywood cracks ~1.5-2% (DESIGN.md, FIX1)
+MIN_RAMP_DEG = 20.0
+MAX_RAMP_DEG = 60.0
 
 
 @pytest.fixture(scope="session")
@@ -90,69 +111,228 @@ def _lines(path_d: str) -> list[svgpathtools.Line]:
     return [seg for seg in svgpathtools.parse_path(path_d) if isinstance(seg, svgpathtools.Line)]
 
 
-def _find_nub_flat_top(slot_hole) -> tuple[float, float, float]:
-    """Within the wall's lid-slot-with-nub hole path, find the nub's flat
-    top segment: a short horizontal Line noticeably higher (smaller SVG y)
-    than the slot's own floor level (bbox.ymax). Returns
-    (svg_y, x_start, x_end) of that segment.
+def _nub_bump_geometry(path_d: str) -> dict:
+    """Extract a ramped-nub bump's geometry from ANY closed path that
+    contains it -- a hole (mechanism A's lid-slot-with-nub) or an outer
+    boundary (mechanism B's drawer-side nub) -- by finding the exactly-2
+    non-axis-aligned ("diagonal") Line segments on the path: these are the
+    nub's two ramps, since every OTHER segment on these designs (slot/
+    panel edges, finger teeth, rounded corners drawn as arcs) is axis-
+    aligned or not a Line at all. Fails loudly (assertion) if that
+    assumption doesn't hold -- e.g. a squared-off nub (no ramp) or a
+    missing nub leaves 0 or the wrong count of diagonal segments.
+
+    Returns a dict with base_left/base_right/top_left/top_right (X coords,
+    SVG space), base_y/top_y (SVG Y of the flat base plane / bump peak),
+    and ramp1_len/ramp2_len (the two ramp segment lengths, for slope
+    checks).
     """
-    lines = _lines(slot_hole.d)
-    floor_y = slot_hole.bbox.ymax
-    candidates = []
-    for seg in lines:
-        y0, y1 = seg.start.imag, seg.end.imag
-        if abs(y0 - y1) > 1e-6:
-            continue  # not horizontal
-        length = abs(seg.end.real - seg.start.real)
-        if length > 6.0:
-            continue  # not a short nub-top run (the base/floor runs are long)
-        if floor_y - y0 < 0.3:
-            continue  # not meaningfully above the floor level
-        candidates.append((y0, seg.start.real, seg.end.real))
-    assert len(candidates) == 1, (
-        f"expected exactly 1 nub flat-top segment in the lid-slot hole, found {len(candidates)}"
+    all_lines = _lines(path_d)
+    diagonal = [
+        s for s in all_lines
+        if abs(s.start.real - s.end.real) > 1e-6 and abs(s.start.imag - s.end.imag) > 1e-6
+    ]
+    assert len(diagonal) == 2, (
+        f"expected exactly 2 ramp (non-axis-aligned) segments forming a nub, "
+        f"found {len(diagonal)} -- a squared-off nub or a missing nub would both "
+        f"fail this differently than intended, so this must be exactly 2"
     )
-    return candidates[0]
+    d1, d2 = diagonal
+    if (d1.start.real + d1.end.real) > (d2.start.real + d2.end.real):
+        d1, d2 = d2, d1
+
+    # Each ramp's own two endpoints are exactly {base_y, top_y} -- both
+    # ramps share the SAME pair, so set intersection can't tell them apart.
+    # Instead, count how often each Y value shows up across every
+    # HORIZONTAL segment on the whole path: the flat baseline (floor runs,
+    # finger teeth, ...) repeats at base_y many times, while the short flat
+    # top of the bump is the only thing at top_y -- so top_y is the value
+    # from this ramp's own endpoint pair that appears LESS often overall.
+    horizontal_ys = [
+        round(s.start.imag, 3) for s in all_lines if abs(s.start.imag - s.end.imag) < 1e-6
+    ]
+    y_counts: dict[float, int] = {}
+    for y in horizontal_ys:
+        y_counts[y] = y_counts.get(y, 0) + 1
+
+    candidate_ys = {round(d1.start.imag, 3), round(d1.end.imag, 3)}
+    top_y = min(candidate_ys, key=lambda y: y_counts.get(y, 0))
+
+    def split(seg):
+        pts = [(seg.start.real, seg.start.imag), (seg.end.real, seg.end.imag)]
+        base = max(pts, key=lambda p: abs(round(p[1], 3) - top_y))
+        top = min(pts, key=lambda p: abs(round(p[1], 3) - top_y))
+        return base, top
+
+    (base_left_x, base_y), (top_left_x, _) = split(d1)
+    (base_right_x, base_y2), (top_right_x, _) = split(d2)
+
+    return {
+        "base_left": base_left_x, "base_right": base_right_x,
+        "top_left": top_left_x, "top_right": top_right_x,
+        "base_y": base_y, "base_y2": base_y2, "top_y": top_y,
+        "ramp1_len": d1.length(), "ramp2_len": d2.length(),
+    }
+
+
+def _deepest_y_excluding_nub(path_d: str, top_y: float, tol: float = 0.5) -> float:
+    """Max SVG-y (deepest point) across every Line segment's endpoints,
+    excluding anything within `tol` of the nub's own peak (top_y) -- i.e.
+    the next-deepest real feature on the boundary (for the drawer side
+    wall, the finger tabs' own reach)."""
+    ys = [
+        y for seg in _lines(path_d) for y in (seg.start.imag, seg.end.imag)
+        if abs(y - top_y) > tol
+    ]
+    assert ys, "no boundary points found outside the nub's own peak"
+    return max(ys)
+
+
+def _ramp_slope_degrees(bump: dict) -> tuple[float, float]:
+    """Slope angle (from the flat base plane) of each ramp, in degrees."""
+    rise = abs(bump["top_y"] - bump["base_y"])
+    run1 = abs(bump["top_left"] - bump["base_left"])
+    run2 = abs(bump["base_right"] - bump["top_right"])
+    return math.degrees(math.atan2(rise, run1)), math.degrees(math.atan2(rise, run2))
 
 
 # =============================================================================
-# 1. Wall nub tip Z + slot ceiling clearance
+# 1. Wall lid detent (mechanism A): existence, fixed bounds, ramp, mirror
 # =============================================================================
 
-@pytest.mark.parametrize("side,mirror", WALL_SIDES)
-def test_wall_nub_tip_height(side, mirror):
+def _find_wall_slot(side: str) -> tuple:
     piece = _piece(SHELL_SVG, side)
     matches = _cut_holes_matching(piece, LID_SLOT_LENGTH, c.LID_SLOT_HEIGHT, tol=0.5)
-    assert len(matches) == 1
-    slot = matches[0]
+    assert len(matches) == 1, f"{side}: expected exactly 1 lid-slot hole, found {len(matches)}"
+    return piece, matches[0]
 
-    nub_y, _, _ = _find_nub_flat_top(slot)
-    nub_z = _wall_box_z(piece, nub_y)
-    assert abs(nub_z - c.LID_DETENT_NUB_TOP_Z) <= 0.4, (
-        f"{side}: nub top at Z={nub_z:.2f}, expected LID_DETENT_NUB_TOP_Z={c.LID_DETENT_NUB_TOP_Z:.2f}"
+
+@pytest.mark.parametrize("side,mirror", WALL_SIDES)
+def test_wall_nub_exists_with_ramp_and_rises_past_lid_play(side, mirror):
+    """EXISTENCE + FIXED BOUNDS: the wall's lid-slot hole must carry a real
+    ramped nub (not a plain rectangle -- mutation (i)-equivalent for this
+    mechanism), whose rise clears the lid's own 0.8mm vertical play by a
+    real margin (mutation (a): LID_DETENT_ENGAGE 1.5->0.5 must fail this),
+    and whose ramp is a genuine slope, not a squared-off nub (mutation
+    (h): DETENT_RAMP_DEG->90)."""
+    piece, slot = _find_wall_slot(side)
+    bump = _nub_bump_geometry(slot.d)
+
+    base_top_width = abs(bump["top_right"] - bump["top_left"])
+    base_width = abs(bump["base_right"] - bump["base_left"])
+    assert base_width > base_top_width, (
+        f"{side}: nub base width ({base_width:.2f}) is not wider than its top "
+        f"({base_top_width:.2f}) -- no ramp"
     )
-    # Nub top must clear the slot ceiling (LID_SLOT_TOP) with real margin --
-    # it should never be able to jam against the rail above the slot.
-    clearance = c.LID_SLOT_TOP - nub_z
-    assert clearance >= 1.0, (
-        f"{side}: nub top Z={nub_z:.2f} leaves only {clearance:.2f}mm below the slot "
-        f"ceiling {c.LID_SLOT_TOP} -- must clear with margin"
+
+    for angle in _ramp_slope_degrees(bump):
+        assert MIN_RAMP_DEG <= angle <= MAX_RAMP_DEG, (
+            f"{side}: ramp angle {angle:.1f} deg outside [{MIN_RAMP_DEG}, {MAX_RAMP_DEG}] "
+            f"-- mutation-detectable square nub or too-shallow ramp"
+        )
+
+    floor_z = _wall_box_z(piece, bump["base_y"])
+    nub_z = _wall_box_z(piece, bump["top_y"])
+    rise = nub_z - floor_z
+    assert rise >= LID_VERTICAL_PLAY + 0.4, (
+        f"{side}: nub rise {rise:.2f}mm above the measured slot floor does not clear "
+        f"the lid's own {LID_VERTICAL_PLAY}mm vertical play + 0.4mm margin"
     )
-    # And it must actually rise above the slot floor by the configured
-    # engagement (not accidentally sit at/below the floor level).
-    rise = nub_z - c.LID_SLOT_BOTTOM
-    assert rise == pytest.approx(c.LID_DETENT_ENGAGE, abs=0.4)
+    # Direction sanity: the nub must rise INTO the slot (toward the ceiling),
+    # not the reverse (mutation (b): wall nub flipped downward).
+    ceiling_z = _wall_box_z(piece, slot.bbox.ymin)
+    assert floor_z < ceiling_z, "sanity: measured floor should read a lower Z than the ceiling"
+    assert floor_z < nub_z < ceiling_z, (
+        f"{side}: nub top Z={nub_z:.2f} is not between the measured floor "
+        f"({floor_z:.2f}) and ceiling ({ceiling_z:.2f}) -- nub may be inverted"
+    )
+
+
+@pytest.mark.parametrize("side,mirror", WALL_SIDES)
+def test_wall_release_cut_exists_and_leaves_root_solid(side, mirror):
+    """EXISTENCE: the cantilever release cut (cavity + severing slot) must
+    actually exist near the nub (mutation (f): delete the wall release cut
+    must fail this)."""
+    piece = _piece(SHELL_SVG, side)
+    _, slot = _find_wall_slot(side)
+    bump = _nub_bump_geometry(slot.d)
+    nub_cx = (bump["top_left"] + bump["top_right"]) / 2
+
+    # The release cut sits just below the slot floor (smaller box Z, larger
+    # SVG y): small rectangular holes within a few mm of the nub's own X,
+    # spanning a compact Z band below the slot.
+    floor_y = slot.bbox.ymax
+    candidates = [
+        h for h in _blue_holes(piece)
+        if h.bbox.ymin >= floor_y - 0.5
+        and abs((h.bbox.xmin + h.bbox.xmax) / 2 - nub_cx) <= 25.0
+        and h.bbox.height <= 12.0
+    ]
+    assert len(candidates) >= 2, (
+        f"{side}: expected >= 2 release-cut holes (cavity + sever) below the slot "
+        f"floor near the nub, found {len(candidates)}"
+    )
+    widths = sorted(h.bbox.width for h in candidates)
+    assert widths[0] <= 3.0, f"{side}: no narrow (sever) release-cut hole found: widths {widths}"
+    assert widths[-1] >= 10.0, f"{side}: no wide (cavity) release-cut hole found: widths {widths}"
+
+
+def test_wall_detents_are_true_mirrors():
+    box_x_by_side = {}
+    for side, mirror in WALL_SIDES:
+        piece, slot = _find_wall_slot(side)
+        bump = _nub_bump_geometry(slot.d)
+        nub_x_svg = (bump["top_left"] + bump["top_right"]) / 2
+        to_box_x = _wall_frame(piece, mirror)
+        box_x_by_side[side] = to_box_x(nub_x_svg)
+
+    right_x, left_x = box_x_by_side["right wall"], box_x_by_side["left wall"]
+    assert abs(right_x - left_x) <= 0.6, (
+        f"wall nubs land at different box X positions: right={right_x:.2f}, "
+        f"left={left_x:.2f} -- mirroring is broken (mutation (d))"
+    )
+
+
+@pytest.mark.parametrize("side,mirror", WALL_SIDES)
+def test_wall_nub_strain_within_crack_threshold(side, mirror):
+    """Beam strain formula eps = 3*w*delta/(2*L^2), computed ENTIRELY from
+    measured SVG dimensions (root-to-nub span from the release cut's own
+    measured extent, rise from the nub bump itself), not config echoes."""
+    piece = _piece(SHELL_SVG, side)
+    _, slot = _find_wall_slot(side)
+    bump = _nub_bump_geometry(slot.d)
+    nub_cx = (bump["top_left"] + bump["top_right"]) / 2
+    floor_y = slot.bbox.ymax
+
+    cavity_candidates = [
+        h for h in _blue_holes(piece)
+        if h.bbox.ymin >= floor_y - 0.5
+        and abs((h.bbox.xmin + h.bbox.xmax) / 2 - nub_cx) <= 25.0
+        and h.bbox.width >= 10.0
+    ]
+    assert len(cavity_candidates) == 1, (
+        f"{side}: expected exactly 1 wide (cavity) release-cut hole, found {len(cavity_candidates)}"
+    )
+    cavity = cavity_candidates[0].bbox
+    root_x = cavity.xmax if abs(cavity.xmax - nub_cx) > abs(cavity.xmin - nub_cx) else cavity.xmin
+    span = abs(root_x - nub_cx)
+    assert span > 5.0, f"{side}: measured root-to-nub span implausibly small ({span:.2f})"
+
+    rise = abs(bump["top_y"] - bump["base_y"])
+    w = cavity.height  # measured beam/cavity cross-section width
+    eps = 3 * w * rise / (2 * span ** 2) * 100
+    assert eps <= MAX_STRAIN_PCT, (
+        f"{side}: measured beam strain {eps:.2f}% exceeds the {MAX_STRAIN_PCT}% "
+        f"plywood crack threshold (span={span:.2f}, rise={rise:.2f}, w={w:.2f})"
+    )
 
 
 # =============================================================================
-# 2 + 3. Lid notch aligns with the wall nub's X position when closed;
-# notch depth clears the lid-slot engagement with margin
+# 2. Lid mating notch
 # =============================================================================
 
 def test_lid_notch_aligns_with_wall_nub_when_closed():
     lid = _piece(LIDS_SVG, "sliding lid")
-    # Find both notches: edge-open holes whose bbox width matches
-    # LID_NOTCH_WIDTH and whose bbox touches one of the lid's Y edges.
     notch_matches = [
         h for h in _blue_holes(lid)
         if abs(h.bbox.width - c.LID_NOTCH_WIDTH) <= 1.0
@@ -163,24 +343,21 @@ def test_lid_notch_aligns_with_wall_nub_when_closed():
         f"found {len(notch_matches)}"
     )
 
+    piece, slot = _find_wall_slot("right wall")
+    bump = _nub_bump_geometry(slot.d)
+    to_box_x = _wall_frame(piece, mirror=False)
+    nub_box_x = to_box_x((bump["top_left"] + bump["top_right"]) / 2)
+
     for notch in notch_matches:
         notch_cx = (notch.bbox.xmin + notch.bbox.xmax) / 2
-        lid_local_x = notch_cx - lid.bbox.xmin  # lid's front edge is a clean anchor (plain, unjointed)
-        assert abs(lid_local_x - c.LID_NOTCH_X) <= 0.6, (
-            f"notch center lid-local X={lid_local_x:.2f}, expected LID_NOTCH_X={c.LID_NOTCH_X}"
-        )
-
-        # Explicit coordinate transform: when the lid is closed, lid-local X
-        # maps to box X via + LID_CLOSED_FRONT_X (DESIGN.md #8 -- the lid's
-        # front edge sits at box X = LID_CLOSED_FRONT_X when fully inserted).
+        lid_local_x = notch_cx - lid.bbox.xmin
         box_x_when_closed = lid_local_x + c.LID_CLOSED_FRONT_X
-        assert abs(box_x_when_closed - c.LID_DETENT_X) <= 0.6, (
-            f"notch maps to box X={box_x_when_closed:.2f} when closed, expected the "
-            f"wall nub's box X={c.LID_DETENT_X} (LID_DETENT_X)"
+        assert abs(box_x_when_closed - nub_box_x) <= 0.6, (
+            f"notch maps to box X={box_x_when_closed:.2f} when closed, but the "
+            f"MEASURED wall nub is at box X={nub_box_x:.2f} (mutation (c): notch "
+            f"shifted +5mm must fail this independent-datum comparison)"
         )
 
-        # Depth: notch cuts inward from the lid's own edge by >= the lid's
-        # slot engagement (2.425mm) plus margin, per DESIGN.md's derivation.
         lid_slot_engagement = (c.SLIDING_LID["width"] - c.INTERIOR_WIDTH) / 2
         depth = notch.bbox.height
         assert depth >= lid_slot_engagement + 0.5, (
@@ -190,146 +367,248 @@ def test_lid_notch_aligns_with_wall_nub_when_closed():
 
 
 # =============================================================================
-# 4. Left/right wall detents are true mirrors
+# 3. Drawer side-wall flexure (mechanism B, iteration 3)
 # =============================================================================
 
-def test_wall_detents_are_true_mirrors():
-    box_x_by_side = {}
-    for side, mirror in WALL_SIDES:
-        piece = _piece(SHELL_SVG, side)
-        matches = _cut_holes_matching(piece, LID_SLOT_LENGTH, c.LID_SLOT_HEIGHT, tol=0.5)
-        assert len(matches) == 1
-        nub_y, x0, x1 = _find_nub_flat_top(matches[0])
-        nub_x_svg = (x0 + x1) / 2
-        to_box_x = _wall_frame(piece, mirror)
-        box_x_by_side[side] = to_box_x(nub_x_svg)
+@pytest.mark.parametrize("side", DRAWER_SIDES)
+def test_drawer_side_nub_exists_with_ramp_and_clears_opening_play(side):
+    """EXISTENCE + FIXED BOUNDS: each drawer side wall must carry a real
+    ramped nub protruding past its own bottom edge (mutation (i): a plain
+    rectangle must fail), whose protrusion clears the drawer's own 1.5mm
+    opening vertical clearance by a real margin (mutation (e):
+    DRAWER_DETENT_ENGAGE 2.2->1.0 must fail this)."""
+    piece = _piece(DRAWER_SVG, side)
+    bump = _nub_bump_geometry(piece.outer.d)
 
-    right_x, left_x = box_x_by_side["right wall"], box_x_by_side["left wall"]
-    assert abs(right_x - left_x) <= 0.6, (
-        f"wall nubs land at different box X positions: right={right_x:.2f}, "
-        f"left={left_x:.2f} -- mirroring is broken"
+    base_top_width = abs(bump["top_right"] - bump["top_left"])
+    base_width = abs(bump["base_right"] - bump["base_left"])
+    assert base_width > base_top_width, (
+        f"{side}: nub base width ({base_width:.2f}) is not wider than its top "
+        f"({base_top_width:.2f}) -- no ramp"
     )
-    assert abs(right_x - c.LID_DETENT_X) <= 0.6
+    for angle in _ramp_slope_degrees(bump):
+        assert MIN_RAMP_DEG <= angle <= MAX_RAMP_DEG, (
+            f"{side}: ramp angle {angle:.1f} deg outside [{MIN_RAMP_DEG}, {MAX_RAMP_DEG}]"
+        )
+
+    # The nub's own protrusion BEYOND the neighboring finger tabs' own reach
+    # (the piece's deepest point EXCLUDING the nub itself, since the nub is
+    # now the overall bbox extreme) is what matters -- not the nub's total
+    # depth from the plain zone's local y=0 baseline (bump["base_y"], which
+    # sits ABOVE (shallower than) the tab reach, since the plain zone has
+    # no tab there at all -- see generate_drawers.py's _build_side).
+    tab_reach_y = _deepest_y_excluding_nub(piece.outer.d, bump["top_y"])
+    protrusion = bump["top_y"] - tab_reach_y
+    assert protrusion > 0, (
+        f"{side}: nub top is not deeper than the piece's own tab reach "
+        f"(top_y={bump['top_y']:.2f}, tab_reach={tab_reach_y:.2f}) -- nub may be inverted"
+    )
+    assert protrusion >= DRAWER_OPENING_VERTICAL_PLAY + 0.5, (
+        f"{side}: measured nub protrusion past the piece's own tab-reach depth "
+        f"({protrusion:.2f}mm) does not clear the drawer's {DRAWER_OPENING_VERTICAL_PLAY}mm "
+        f"opening vertical clearance + 0.5mm margin"
+    )
+
+
+@pytest.mark.parametrize("side", DRAWER_SIDES)
+def test_drawer_side_release_cut_exists(side):
+    """EXISTENCE: the cantilever release cut (cavity + sever) near the nub
+    (mutation (i) catch, distinct from the boundary-shape check above)."""
+    piece = _piece(DRAWER_SVG, side)
+    bump = _nub_bump_geometry(piece.outer.d)
+    nub_cx = (bump["top_left"] + bump["top_right"]) / 2
+
+    candidates = [
+        h for h in _blue_holes(piece)
+        if abs((h.bbox.xmin + h.bbox.xmax) / 2 - nub_cx) <= 30.0
+        and h.bbox.height <= 12.0
+    ]
+    assert len(candidates) >= 2, (
+        f"{side}: expected >= 2 release-cut holes (cavity + sever) near the nub, "
+        f"found {len(candidates)}"
+    )
+    widths = sorted(h.bbox.width for h in candidates)
+    assert widths[0] <= 3.0, f"{side}: no narrow (sever) release-cut hole found: widths {widths}"
+    assert widths[-1] >= 15.0, f"{side}: no wide (cavity) release-cut hole found: widths {widths}"
+
+
+@pytest.mark.parametrize("side", DRAWER_SIDES)
+def test_drawer_side_nub_clear_of_front_finger_joints(side):
+    """The nub (and its release cut) must stay >= 15mm clear of the
+    front-edge finger joints (the vertical edge at the piece's own X
+    extreme nearest the nub)."""
+    piece = _piece(DRAWER_SVG, side)
+    bump = _nub_bump_geometry(piece.outer.d)
+    nub_cx = (bump["top_left"] + bump["top_right"]) / 2
+
+    dist_from_left_edge = nub_cx - piece.bbox.xmin
+    dist_from_right_edge = piece.bbox.xmax - nub_cx
+    nearest_edge_dist = min(dist_from_left_edge, dist_from_right_edge)
+    assert nearest_edge_dist >= 15.0, (
+        f"{side}: nub is only {nearest_edge_dist:.2f}mm from the nearest end of the "
+        f"panel -- must clear the front finger joints by >= 15mm"
+    )
+
+
+@pytest.mark.parametrize("side", DRAWER_SIDES)
+def test_drawer_side_strain_within_crack_threshold(side):
+    """Beam strain formula, computed from measured SVG dimensions."""
+    piece = _piece(DRAWER_SVG, side)
+    bump = _nub_bump_geometry(piece.outer.d)
+    nub_cx = (bump["top_left"] + bump["top_right"]) / 2
+
+    cavity_candidates = [
+        h for h in _blue_holes(piece)
+        if abs((h.bbox.xmin + h.bbox.xmax) / 2 - nub_cx) <= 30.0
+        and h.bbox.width >= 15.0
+    ]
+    assert len(cavity_candidates) == 1, (
+        f"{side}: expected exactly 1 wide (cavity) release-cut hole, found {len(cavity_candidates)}"
+    )
+    cavity = cavity_candidates[0].bbox
+    root_x = cavity.xmax if abs(cavity.xmax - nub_cx) > abs(cavity.xmin - nub_cx) else cavity.xmin
+    span = abs(root_x - nub_cx)
+    assert span > 5.0, f"{side}: measured root-to-nub span implausibly small ({span:.2f})"
+
+    # The strain-relevant deflection is the nub's protrusion PAST the
+    # surrounding tab reach -- the beam only has to flex that far to become
+    # flush with its neighbors, not all the way from the (already-recessed)
+    # plain-zone baseline -- see the protrusion test above for the same
+    # reasoning.
+    tab_reach_y = _deepest_y_excluding_nub(piece.outer.d, bump["top_y"])
+    rise = bump["top_y"] - tab_reach_y
+    assert rise > 0
+    w = cavity.height
+    eps = 3 * w * rise / (2 * span ** 2) * 100
+    assert eps <= MAX_STRAIN_PCT, (
+        f"{side}: measured beam strain {eps:.2f}% exceeds the {MAX_STRAIN_PCT}% "
+        f"plywood crack threshold (span={span:.2f}, rise={rise:.2f}, w={w:.2f})"
+    )
 
 
 # =============================================================================
-# 5. Faceplate overall width including nubs
+# 4. Faceplate BLANK INVARIANT: back to the exact v1 plain rectangle
 # =============================================================================
 
-def test_faceplate_width_includes_nubs_and_exceeds_opening_interference():
+def test_faceplate_has_no_nub_or_ramp():
+    """The faceplate's iteration-2 detent is REMOVED entirely (FIX1): its
+    outer boundary must be a plain rectangle with zero diagonal (ramp)
+    segments -- test_svg_geometry.py's restored test_faceplate_blank_size
+    covers the overall v1 dimension (150.9mm); this covers the SHAPE, which
+    a size-only check can't (a reintroduced nub whose footprint still fits
+    inside a slightly-loose band would pass a size check but not this)."""
     piece = _piece(DRAWER_SVG, "faceplate")
-    expected_width = c.FACEPLATE["width"] + 2 * c.DRAWER_DETENT_PROTRUDE
-    assert piece.bbox.width == pytest.approx(expected_width, abs=0.5), (
-        f"faceplate drawn width {piece.bbox.width:.2f}, expected {expected_width:.2f} "
-        f"(FACEPLATE width + 2*DRAWER_DETENT_PROTRUDE)"
-    )
-    # The nub-inclusive width must exceed the opening width -- i.e. genuine
-    # interference, not just filling the reveal.
-    assert piece.bbox.width > c.OPENING_WIDTH, (
-        f"faceplate nub-inclusive width {piece.bbox.width:.2f} does not exceed the "
-        f"opening width {c.OPENING_WIDTH} -- no real interference"
-    )
-    interference_per_side = (piece.bbox.width - c.OPENING_WIDTH) / 2
-    assert interference_per_side > 0
-
-
-# =============================================================================
-# 6. Nubs don't intersect the grip slot / other features; clearance margins
-# =============================================================================
-
-def test_faceplate_nubs_clear_grip_slot():
-    piece = _piece(DRAWER_SVG, "faceplate")
-    grip = _cut_holes_matching(piece, c.DRAWER_GRIP_SLOT["width"], c.DRAWER_GRIP_SLOT["height"], tol=1.0)
-    assert len(grip) == 1
-    grip_bbox = grip[0].bbox
-
-    # Nubs sit near the Y edges (piece bbox.xmin / bbox.xmax); the grip slot
-    # is Y-centered. Confirm real X separation between the nub region and
-    # the grip slot -- no overlap, and >= 3mm gap either side.
-    nub_region_from_left = piece.bbox.xmin + c.DETENT_BEAM_WIDTH + c.DETENT_CLEARANCE
-    nub_region_from_right = piece.bbox.xmax - c.DETENT_BEAM_WIDTH - c.DETENT_CLEARANCE
-    assert grip_bbox.xmin - nub_region_from_left >= 3.0, (
-        "faceplate grip slot is within 3mm of the left-edge detent's release cut"
-    )
-    assert nub_region_from_right - grip_bbox.xmax >= 3.0, (
-        "faceplate grip slot is within 3mm of the right-edge detent's release cut"
+    diagonal = [
+        s for s in _lines(piece.outer.d)
+        if abs(s.start.real - s.end.real) > 1e-6 and abs(s.start.imag - s.end.imag) > 1e-6
+    ]
+    assert diagonal == [], (
+        f"faceplate outer boundary has {len(diagonal)} non-axis-aligned segment(s) -- "
+        f"expected a plain v1 rectangle with none"
     )
 
 
-@pytest.mark.parametrize("side,mirror", WALL_SIDES)
-def test_wall_nub_clears_divider_and_shelf_hole_lines(side, mirror):
-    """Nub/beam must stay >= 3mm from the (measured, real) divider
-    finger-hole column and stay entirely above the (measured, real) shelf
-    hole line's Z band."""
-    piece = _piece(SHELL_SVG, side)
-    to_box_x = _wall_frame(piece, mirror)
+def test_drawer_side_blank_height_excluding_nub_matches_v1():
+    """BLANK INVARIANT: the side wall's height, EXCLUDING the nub's own
+    local protrusion (i.e. up to the finger tabs' own reach, the v1 value),
+    measured in SVG-space -- distinct from test_svg_geometry.py's
+    tolerance-banded bbox check (which the nub-inclusive height also
+    happens to pass, since the band's slack absorbs it)."""
+    for side in DRAWER_SIDES:
+        piece = _piece(DRAWER_SVG, side)
+        bump = _nub_bump_geometry(piece.outer.d)
+        # The tab-reach boundary (v1's own bottom edge, the SAME depth the
+        # neighboring finger tabs reach) is the deepest point on the
+        # boundary EXCLUDING the nub itself (which is now the overall bbox
+        # extreme) -- NOT bump["base_y"], the plain zone's own local y=0
+        # baseline, which sits shallower still (no tab there at all).
+        tab_reach_y = _deepest_y_excluding_nub(piece.outer.d, bump["top_y"])
+        height_excl_nub = tab_reach_y - piece.bbox.ymin
+        v1_band_lo, v1_band_hi = su.expected_band(c.DRAWER_BODY["height"], jointed_edges=1, thickness=T)
+        assert v1_band_lo <= height_excl_nub <= v1_band_hi, (
+            f"{side}: blank height excluding the nub ({height_excl_nub:.2f}) outside "
+            f"the v1 band [{v1_band_lo:.2f}, {v1_band_hi:.2f}]"
+        )
 
-    matches = _cut_holes_matching(piece, LID_SLOT_LENGTH, c.LID_SLOT_HEIGHT, tol=0.5)
-    assert len(matches) == 1
-    nub_y, x0, x1 = _find_nub_flat_top(matches[0])
-    nub_box_x = to_box_x((x0 + x1) / 2)
 
-    divider_rows = su.hole_line_rows(_blue_holes(piece), T, axis="y")
-    divider_hits = [r for r in divider_rows if 0.75 * c.DIVIDER_HEIGHT <= r.span <= c.DIVIDER_HEIGHT + 1.0]
-    assert len(divider_hits) == 1
-    divider_box_x = to_box_x(divider_hits[0].center)
-    assert abs(divider_box_x - nub_box_x) >= 3.0, (
-        f"{side}: measured nub (box X={nub_box_x:.2f}) is within 3mm of the measured "
-        f"divider hole column (box X={divider_box_x:.2f})"
+# =============================================================================
+# 5. Catch holes (bottom panel + shelf)
+# =============================================================================
+
+@pytest.mark.parametrize("host,synonyms", [
+    ("bottom panel", ("bottom",)),
+    ("shelf", ("horizontal shelf", "shelf")),
+])
+def test_catch_holes_exist_with_fixed_y_span(host, synonyms):
+    """EXISTENCE + FIXED BOUNDS: two catch holes per host panel (one per
+    drawer side), each with Y-span >= nub thickness + both drawers' full
+    lateral float (LITERALS, mutation (j): catch hole Y-width halved must
+    fail this)."""
+    piece = _piece(SHELL_SVG, *synonyms)
+    min_span = T + 2 * DRAWER_LATERAL_FLOAT_PER_SIDE
+    candidates = [
+        h for h in _blue_holes(piece)
+        if h.bbox.width < h.bbox.height  # narrow-X, wide-Y (unlike finger-hole rows)
+        and 8.0 <= h.bbox.width <= 16.0
+        and h.bbox.height >= min_span
+    ]
+    assert len(candidates) == 2, (
+        f"{host}: expected exactly 2 catch holes with Y-span >= {min_span:.2f}mm "
+        f"(T + 2*{DRAWER_LATERAL_FLOAT_PER_SIDE}mm), found {len(candidates)}"
     )
 
-    # Two bay-length rows exist on each wall (shelf + top-panel, see
-    # test_side_wall_has_shelf_and_top_panel_hole_lines); the shelf row is
-    # the one further from the top edge (larger SVG y = lower box Z).
-    shelf_rows_x = su.hole_line_rows(_blue_holes(piece), T, axis="x")
-    shelf_hits = [r for r in shelf_rows_x if 0.75 * c.BAY_LENGTH <= r.span <= c.BAY_LENGTH + 1.0]
-    assert len(shelf_hits) == 2, f"{side}: expected 2 bay-length hole rows (shelf + top panel)"
-    shelf_row = max(shelf_hits, key=lambda r: r.center)
-    shelf_z = _wall_box_z(piece, shelf_row.center)
-    assert abs(shelf_z - c.LID_DETENT_NUB_TOP_Z) >= 40.0, (
-        f"{side}: the shelf hole row (Z={shelf_z:.2f}) is unexpectedly close to "
-        f"the nub (Z={c.LID_DETENT_NUB_TOP_Z})"
+
+def test_catch_holes_at_same_box_x_on_both_panels():
+    """The bottom panel's and shelf's catch holes must land at the SAME box
+    X (both drawers are identical, closed at the same relative position)."""
+    bottom = _piece(SHELL_SVG, "bottom")
+    shelf = _piece(SHELL_SVG, "horizontal shelf", "shelf")
+    min_span = T + 2 * DRAWER_LATERAL_FLOAT_PER_SIDE
+
+    def catch_holes(piece):
+        return [
+            h for h in _blue_holes(piece)
+            if h.bbox.width < h.bbox.height and 8.0 <= h.bbox.width <= 16.0
+            and h.bbox.height >= min_span
+        ]
+
+    bottom_holes = catch_holes(bottom)
+    shelf_holes = catch_holes(shelf)
+    assert len(bottom_holes) == 2 and len(shelf_holes) == 2
+
+    # Bottom panel: fingers protrude T on all 4 edges (DESIGN.md #1), so
+    # bbox.xmin sits at box X = 0 exactly (same anchor as
+    # test_svg_geometry.py's test_bottom_panel_divider_row_position) -- box
+    # X = measured - bbox.xmin directly.
+    # Shelf: the REAR edge (local x=BAY_LENGTH) is plain ("e", DESIGN.md
+    # #6 -- "rear edge plain, butting the rear wall"), so bbox.xmax sits at
+    # box X = BAY_X1 exactly with no tab to correct for (the FRONT/divider
+    # edge is the jointed one here, so bbox.xmin is not a clean anchor).
+    bottom_box_xs = sorted((h.bbox.xmin + h.bbox.xmax) / 2 - bottom.bbox.xmin for h in bottom_holes)
+    shelf_box_xs = sorted(
+        c.BAY_X1 - (shelf.bbox.xmax - (h.bbox.xmin + h.bbox.xmax) / 2) for h in shelf_holes
     )
+    for bx, sx in zip(bottom_box_xs, shelf_box_xs):
+        assert abs(bx - sx) <= 0.6, (
+            f"bottom-panel catch hole at box X={bx:.2f} does not match shelf's "
+            f"catch hole at box X={sx:.2f} -- both drawers close to the same position"
+        )
 
 
 # =============================================================================
-# 7. Beam clearance cuts leave structural webs intact / don't touch the rail
+# 6. Retention coupon pieces present (5 now: wall sample, lid notch strip,
+#    drawer-side sample, mock sill edge, mock floor strip)
 # =============================================================================
 
-@pytest.mark.parametrize("side,mirror", WALL_SIDES)
-def test_wall_release_cut_does_not_touch_top_rail_or_bottom_row(side, mirror):
-    piece = _piece(SHELL_SVG, side)
-
-    # The release cut's cavity + severing slot are small rectangular holes
-    # near LID_DETENT_CAVITY_BOTTOM_Z..LID_DETENT_BEAM_BOTTOM_Z; none of the
-    # wall's holes may extend above the slot floor (into the 5mm top rail)
-    # or down into the bottom-panel finger-hole row's Z band.
-    for h in _blue_holes(piece):
-        z_top = _wall_box_z(piece, h.bbox.ymin)
-        z_bottom = _wall_box_z(piece, h.bbox.ymax)
-        hi, lo = max(z_top, z_bottom), min(z_top, z_bottom)
-        if hi <= c.LID_SLOT_TOP + 0.1 and lo >= c.LID_DETENT_CAVITY_BOTTOM_Z - 3.0 and (hi - lo) < 10:
-            # A candidate detent-area hole (small, sits below the slot
-            # floor): must not creep up into the rail above LID_SLOT_TOP,
-            # and must stay clear of the bottom-panel row at Z ~= T/2.
-            assert hi <= c.LID_SLOT_TOP + 0.5, f"{side}: a detent-area hole reaches into the top rail"
-            assert lo >= (T / 2) + c.MIN_WEB, (
-                f"{side}: a detent-area hole reaches down toward the bottom-panel row"
-            )
-
-
-# =============================================================================
-# 8. Retention coupon pieces present
-# =============================================================================
-
-def test_retention_coupon_has_all_four_pieces(retention_coupon_svg):
+def test_retention_coupon_has_all_five_pieces(retention_coupon_svg):
     pieces = su.design_pieces(retention_coupon_svg)
     labels = {p.label for p in pieces}
     expected = {
         "Retention: Wall Flexure Sample",
         "Retention: Lid Notch Strip",
-        "Retention: Faceplate Flexure Sample",
-        "Retention: Mock Opening Edge",
+        "Retention: Drawer-Side Flexure Sample",
+        "Retention: Mock Sill Edge",
+        "Retention: Mock Floor Strip",
     }
     assert expected <= labels, f"missing retention coupon pieces: {expected - labels}; found: {labels}"
 
@@ -338,20 +617,28 @@ def test_retention_coupon_wall_sample_has_nub_and_release_cut(retention_coupon_s
     pieces = su.design_pieces(retention_coupon_svg)
     sample = su.find_piece_by_label(pieces, "Wall Flexure Sample")
     assert sample is not None
-    # The slot-with-nub hole should be the largest hole (spans most of the
-    # sample's width); the release cut shows up as 2 additional smaller
-    # holes (cavity + severing slot).
     assert len(sample.holes) >= 3, (
         f"expected >= 3 holes (slot-with-nub + cavity + severing slot) on the wall "
         f"flexure sample, found {len(sample.holes)}"
     )
 
 
-def test_retention_coupon_faceplate_sample_has_release_cut(retention_coupon_svg):
+def test_retention_coupon_drawer_sample_has_nub_and_release_cut(retention_coupon_svg):
     pieces = su.design_pieces(retention_coupon_svg)
-    sample = su.find_piece_by_label(pieces, "Faceplate Flexure Sample")
+    sample = su.find_piece_by_label(pieces, "Drawer-Side Flexure Sample")
     assert sample is not None
+    bump = _nub_bump_geometry(sample.outer.d)
+    assert abs(bump["base_right"] - bump["base_left"]) > abs(bump["top_right"] - bump["top_left"]), (
+        "drawer-side flexure sample's nub has no ramp"
+    )
     assert len(sample.holes) >= 2, (
-        f"expected >= 2 holes (cavity + severing slot) on the faceplate flexure "
+        f"expected >= 2 holes (cavity + severing slot) on the drawer-side flexure "
         f"sample, found {len(sample.holes)}"
     )
+
+
+def test_retention_coupon_floor_strip_has_catch_hole(retention_coupon_svg):
+    pieces = su.design_pieces(retention_coupon_svg)
+    strip = su.find_piece_by_label(pieces, "Mock Floor Strip")
+    assert strip is not None
+    assert len(strip.holes) >= 1, "mock floor strip has no catch hole"

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,357 @@
+"""Retention (iteration 2, issue #20) tests: positional/mating assertions on
+the two spring-detent mechanisms, parsing the actual SVGs the same way
+test_svg_geometry.py does (never trusting a predefined mental model of the
+geometry -- see that file's module docstring on why size-only checks aren't
+enough). Policy unchanged from test_svg_geometry.py: never weaken a test to
+pass; existing tests are untouched except the two flagged, documented,
+minimal deviations in test_svg_geometry.py (test_faceplate_blank_size and
+test_edge_polarity_literals_present) that are an unavoidable consequence of
+the faceplate nub becoming a real, physically larger, protruding piece.
+"""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import svgpathtools
+
+from faxbox import config as c
+
+import svg_utils as su
+
+pytestmark = [pytest.mark.usefixtures("regenerate_svgs")]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = REPO_ROOT / "output"
+SHELL_SVG = OUTPUT_DIR / "outer_shell.svg"
+DRAWER_SVG = OUTPUT_DIR / "drawer.svg"
+LIDS_SVG = OUTPUT_DIR / "lids.svg"
+
+T = c.MATERIAL_THICKNESS
+LID_SLOT_LENGTH = c.LID_SLOT_X_END - T
+WALL_SIDES = [("right wall", False), ("left wall", True)]
+
+
+@pytest.fixture(scope="session")
+def retention_coupon_svg():
+    subprocess.run(
+        [sys.executable, "-m", "faxbox.calibration"],
+        check=True, cwd=REPO_ROOT, capture_output=True,
+    )
+    path = OUTPUT_DIR / "retention_coupon.svg"
+    assert path.exists(), "faxbox.calibration did not produce output/retention_coupon.svg"
+    return path
+
+
+def _piece(svg_path, *synonyms):
+    pieces = su.design_pieces(svg_path)
+    found = su.find_piece_by_label(pieces, *synonyms)
+    assert found is not None, f"no piece labeled like {synonyms!r} found in {svg_path.name}"
+    return found
+
+
+def _blue_holes(piece):
+    return [h for h in piece.holes if su.normalize_color(h.stroke) == "blue"]
+
+
+def _cut_holes_matching(piece, width, height, tol=1.0):
+    return [h for h in _blue_holes(piece) if h.bbox.dims_match(width, height, tol=tol)]
+
+
+def _wall_box_z(wall, y: float) -> float:
+    """Same anchor-free mapping as test_svg_geometry.py's _wall_box_z: the
+    side walls' top/bottom edges are never jointed, so bbox.ymin is exactly
+    box Z = WALL_HEIGHT with no correction needed."""
+    return c.WALL_HEIGHT - (y - wall.bbox.ymin)
+
+
+def _wall_frame(wall, mirror: bool):
+    """Same anchor as test_svg_geometry.py's _wall_frame: the divider
+    finger-hole column's X center is box X DIVIDER_MID_BOX_X on both walls."""
+    rows = su.hole_line_rows(_blue_holes(wall), T, axis="y")
+    divider_nominal = c.DIVIDER_HEIGHT
+    hits = [r for r in rows if 0.75 * divider_nominal <= r.span <= divider_nominal + 1.0]
+    assert len(hits) == 1
+    col = hits[0].center
+    divider_mid_box_x = (c.DIVIDER_X0 + c.DIVIDER_X1) / 2
+    sign = -1.0 if mirror else 1.0
+
+    def to_box_x(x: float) -> float:
+        return divider_mid_box_x + sign * (x - col)
+
+    return to_box_x
+
+
+def _lines(path_d: str) -> list[svgpathtools.Line]:
+    return [seg for seg in svgpathtools.parse_path(path_d) if isinstance(seg, svgpathtools.Line)]
+
+
+def _find_nub_flat_top(slot_hole) -> tuple[float, float, float]:
+    """Within the wall's lid-slot-with-nub hole path, find the nub's flat
+    top segment: a short horizontal Line noticeably higher (smaller SVG y)
+    than the slot's own floor level (bbox.ymax). Returns
+    (svg_y, x_start, x_end) of that segment.
+    """
+    lines = _lines(slot_hole.d)
+    floor_y = slot_hole.bbox.ymax
+    candidates = []
+    for seg in lines:
+        y0, y1 = seg.start.imag, seg.end.imag
+        if abs(y0 - y1) > 1e-6:
+            continue  # not horizontal
+        length = abs(seg.end.real - seg.start.real)
+        if length > 6.0:
+            continue  # not a short nub-top run (the base/floor runs are long)
+        if floor_y - y0 < 0.3:
+            continue  # not meaningfully above the floor level
+        candidates.append((y0, seg.start.real, seg.end.real))
+    assert len(candidates) == 1, (
+        f"expected exactly 1 nub flat-top segment in the lid-slot hole, found {len(candidates)}"
+    )
+    return candidates[0]
+
+
+# =============================================================================
+# 1. Wall nub tip Z + slot ceiling clearance
+# =============================================================================
+
+@pytest.mark.parametrize("side,mirror", WALL_SIDES)
+def test_wall_nub_tip_height(side, mirror):
+    piece = _piece(SHELL_SVG, side)
+    matches = _cut_holes_matching(piece, LID_SLOT_LENGTH, c.LID_SLOT_HEIGHT, tol=0.5)
+    assert len(matches) == 1
+    slot = matches[0]
+
+    nub_y, _, _ = _find_nub_flat_top(slot)
+    nub_z = _wall_box_z(piece, nub_y)
+    assert abs(nub_z - c.LID_DETENT_NUB_TOP_Z) <= 0.4, (
+        f"{side}: nub top at Z={nub_z:.2f}, expected LID_DETENT_NUB_TOP_Z={c.LID_DETENT_NUB_TOP_Z:.2f}"
+    )
+    # Nub top must clear the slot ceiling (LID_SLOT_TOP) with real margin --
+    # it should never be able to jam against the rail above the slot.
+    clearance = c.LID_SLOT_TOP - nub_z
+    assert clearance >= 1.0, (
+        f"{side}: nub top Z={nub_z:.2f} leaves only {clearance:.2f}mm below the slot "
+        f"ceiling {c.LID_SLOT_TOP} -- must clear with margin"
+    )
+    # And it must actually rise above the slot floor by the configured
+    # engagement (not accidentally sit at/below the floor level).
+    rise = nub_z - c.LID_SLOT_BOTTOM
+    assert rise == pytest.approx(c.LID_DETENT_ENGAGE, abs=0.4)
+
+
+# =============================================================================
+# 2 + 3. Lid notch aligns with the wall nub's X position when closed;
+# notch depth clears the lid-slot engagement with margin
+# =============================================================================
+
+def test_lid_notch_aligns_with_wall_nub_when_closed():
+    lid = _piece(LIDS_SVG, "sliding lid")
+    # Find both notches: edge-open holes whose bbox width matches
+    # LID_NOTCH_WIDTH and whose bbox touches one of the lid's Y edges.
+    notch_matches = [
+        h for h in _blue_holes(lid)
+        if abs(h.bbox.width - c.LID_NOTCH_WIDTH) <= 1.0
+        and (abs(h.bbox.ymin - lid.bbox.ymin) <= 0.3 or abs(h.bbox.ymax - lid.bbox.ymax) <= 0.3)
+    ]
+    assert len(notch_matches) == 2, (
+        f"expected 2 edge-open notches (one per long edge) on the sliding lid, "
+        f"found {len(notch_matches)}"
+    )
+
+    for notch in notch_matches:
+        notch_cx = (notch.bbox.xmin + notch.bbox.xmax) / 2
+        lid_local_x = notch_cx - lid.bbox.xmin  # lid's front edge is a clean anchor (plain, unjointed)
+        assert abs(lid_local_x - c.LID_NOTCH_X) <= 0.6, (
+            f"notch center lid-local X={lid_local_x:.2f}, expected LID_NOTCH_X={c.LID_NOTCH_X}"
+        )
+
+        # Explicit coordinate transform: when the lid is closed, lid-local X
+        # maps to box X via + LID_CLOSED_FRONT_X (DESIGN.md #8 -- the lid's
+        # front edge sits at box X = LID_CLOSED_FRONT_X when fully inserted).
+        box_x_when_closed = lid_local_x + c.LID_CLOSED_FRONT_X
+        assert abs(box_x_when_closed - c.LID_DETENT_X) <= 0.6, (
+            f"notch maps to box X={box_x_when_closed:.2f} when closed, expected the "
+            f"wall nub's box X={c.LID_DETENT_X} (LID_DETENT_X)"
+        )
+
+        # Depth: notch cuts inward from the lid's own edge by >= the lid's
+        # slot engagement (2.425mm) plus margin, per DESIGN.md's derivation.
+        lid_slot_engagement = (c.SLIDING_LID["width"] - c.INTERIOR_WIDTH) / 2
+        depth = notch.bbox.height
+        assert depth >= lid_slot_engagement + 0.5, (
+            f"notch depth {depth:.2f} does not clear lid-slot engagement "
+            f"{lid_slot_engagement:.2f} + 0.5mm margin"
+        )
+
+
+# =============================================================================
+# 4. Left/right wall detents are true mirrors
+# =============================================================================
+
+def test_wall_detents_are_true_mirrors():
+    box_x_by_side = {}
+    for side, mirror in WALL_SIDES:
+        piece = _piece(SHELL_SVG, side)
+        matches = _cut_holes_matching(piece, LID_SLOT_LENGTH, c.LID_SLOT_HEIGHT, tol=0.5)
+        assert len(matches) == 1
+        nub_y, x0, x1 = _find_nub_flat_top(matches[0])
+        nub_x_svg = (x0 + x1) / 2
+        to_box_x = _wall_frame(piece, mirror)
+        box_x_by_side[side] = to_box_x(nub_x_svg)
+
+    right_x, left_x = box_x_by_side["right wall"], box_x_by_side["left wall"]
+    assert abs(right_x - left_x) <= 0.6, (
+        f"wall nubs land at different box X positions: right={right_x:.2f}, "
+        f"left={left_x:.2f} -- mirroring is broken"
+    )
+    assert abs(right_x - c.LID_DETENT_X) <= 0.6
+
+
+# =============================================================================
+# 5. Faceplate overall width including nubs
+# =============================================================================
+
+def test_faceplate_width_includes_nubs_and_exceeds_opening_interference():
+    piece = _piece(DRAWER_SVG, "faceplate")
+    expected_width = c.FACEPLATE["width"] + 2 * c.DRAWER_DETENT_PROTRUDE
+    assert piece.bbox.width == pytest.approx(expected_width, abs=0.5), (
+        f"faceplate drawn width {piece.bbox.width:.2f}, expected {expected_width:.2f} "
+        f"(FACEPLATE width + 2*DRAWER_DETENT_PROTRUDE)"
+    )
+    # The nub-inclusive width must exceed the opening width -- i.e. genuine
+    # interference, not just filling the reveal.
+    assert piece.bbox.width > c.OPENING_WIDTH, (
+        f"faceplate nub-inclusive width {piece.bbox.width:.2f} does not exceed the "
+        f"opening width {c.OPENING_WIDTH} -- no real interference"
+    )
+    interference_per_side = (piece.bbox.width - c.OPENING_WIDTH) / 2
+    assert interference_per_side > 0
+
+
+# =============================================================================
+# 6. Nubs don't intersect the grip slot / other features; clearance margins
+# =============================================================================
+
+def test_faceplate_nubs_clear_grip_slot():
+    piece = _piece(DRAWER_SVG, "faceplate")
+    grip = _cut_holes_matching(piece, c.DRAWER_GRIP_SLOT["width"], c.DRAWER_GRIP_SLOT["height"], tol=1.0)
+    assert len(grip) == 1
+    grip_bbox = grip[0].bbox
+
+    # Nubs sit near the Y edges (piece bbox.xmin / bbox.xmax); the grip slot
+    # is Y-centered. Confirm real X separation between the nub region and
+    # the grip slot -- no overlap, and >= 3mm gap either side.
+    nub_region_from_left = piece.bbox.xmin + c.DETENT_BEAM_WIDTH + c.DETENT_CLEARANCE
+    nub_region_from_right = piece.bbox.xmax - c.DETENT_BEAM_WIDTH - c.DETENT_CLEARANCE
+    assert grip_bbox.xmin - nub_region_from_left >= 3.0, (
+        "faceplate grip slot is within 3mm of the left-edge detent's release cut"
+    )
+    assert nub_region_from_right - grip_bbox.xmax >= 3.0, (
+        "faceplate grip slot is within 3mm of the right-edge detent's release cut"
+    )
+
+
+@pytest.mark.parametrize("side,mirror", WALL_SIDES)
+def test_wall_nub_clears_divider_and_shelf_hole_lines(side, mirror):
+    """Nub/beam must stay >= 3mm from the (measured, real) divider
+    finger-hole column and stay entirely above the (measured, real) shelf
+    hole line's Z band."""
+    piece = _piece(SHELL_SVG, side)
+    to_box_x = _wall_frame(piece, mirror)
+
+    matches = _cut_holes_matching(piece, LID_SLOT_LENGTH, c.LID_SLOT_HEIGHT, tol=0.5)
+    assert len(matches) == 1
+    nub_y, x0, x1 = _find_nub_flat_top(matches[0])
+    nub_box_x = to_box_x((x0 + x1) / 2)
+
+    divider_rows = su.hole_line_rows(_blue_holes(piece), T, axis="y")
+    divider_hits = [r for r in divider_rows if 0.75 * c.DIVIDER_HEIGHT <= r.span <= c.DIVIDER_HEIGHT + 1.0]
+    assert len(divider_hits) == 1
+    divider_box_x = to_box_x(divider_hits[0].center)
+    assert abs(divider_box_x - nub_box_x) >= 3.0, (
+        f"{side}: measured nub (box X={nub_box_x:.2f}) is within 3mm of the measured "
+        f"divider hole column (box X={divider_box_x:.2f})"
+    )
+
+    # Two bay-length rows exist on each wall (shelf + top-panel, see
+    # test_side_wall_has_shelf_and_top_panel_hole_lines); the shelf row is
+    # the one further from the top edge (larger SVG y = lower box Z).
+    shelf_rows_x = su.hole_line_rows(_blue_holes(piece), T, axis="x")
+    shelf_hits = [r for r in shelf_rows_x if 0.75 * c.BAY_LENGTH <= r.span <= c.BAY_LENGTH + 1.0]
+    assert len(shelf_hits) == 2, f"{side}: expected 2 bay-length hole rows (shelf + top panel)"
+    shelf_row = max(shelf_hits, key=lambda r: r.center)
+    shelf_z = _wall_box_z(piece, shelf_row.center)
+    assert abs(shelf_z - c.LID_DETENT_NUB_TOP_Z) >= 40.0, (
+        f"{side}: the shelf hole row (Z={shelf_z:.2f}) is unexpectedly close to "
+        f"the nub (Z={c.LID_DETENT_NUB_TOP_Z})"
+    )
+
+
+# =============================================================================
+# 7. Beam clearance cuts leave structural webs intact / don't touch the rail
+# =============================================================================
+
+@pytest.mark.parametrize("side,mirror", WALL_SIDES)
+def test_wall_release_cut_does_not_touch_top_rail_or_bottom_row(side, mirror):
+    piece = _piece(SHELL_SVG, side)
+
+    # The release cut's cavity + severing slot are small rectangular holes
+    # near LID_DETENT_CAVITY_BOTTOM_Z..LID_DETENT_BEAM_BOTTOM_Z; none of the
+    # wall's holes may extend above the slot floor (into the 5mm top rail)
+    # or down into the bottom-panel finger-hole row's Z band.
+    for h in _blue_holes(piece):
+        z_top = _wall_box_z(piece, h.bbox.ymin)
+        z_bottom = _wall_box_z(piece, h.bbox.ymax)
+        hi, lo = max(z_top, z_bottom), min(z_top, z_bottom)
+        if hi <= c.LID_SLOT_TOP + 0.1 and lo >= c.LID_DETENT_CAVITY_BOTTOM_Z - 3.0 and (hi - lo) < 10:
+            # A candidate detent-area hole (small, sits below the slot
+            # floor): must not creep up into the rail above LID_SLOT_TOP,
+            # and must stay clear of the bottom-panel row at Z ~= T/2.
+            assert hi <= c.LID_SLOT_TOP + 0.5, f"{side}: a detent-area hole reaches into the top rail"
+            assert lo >= (T / 2) + c.MIN_WEB, (
+                f"{side}: a detent-area hole reaches down toward the bottom-panel row"
+            )
+
+
+# =============================================================================
+# 8. Retention coupon pieces present
+# =============================================================================
+
+def test_retention_coupon_has_all_four_pieces(retention_coupon_svg):
+    pieces = su.design_pieces(retention_coupon_svg)
+    labels = {p.label for p in pieces}
+    expected = {
+        "Retention: Wall Flexure Sample",
+        "Retention: Lid Notch Strip",
+        "Retention: Faceplate Flexure Sample",
+        "Retention: Mock Opening Edge",
+    }
+    assert expected <= labels, f"missing retention coupon pieces: {expected - labels}; found: {labels}"
+
+
+def test_retention_coupon_wall_sample_has_nub_and_release_cut(retention_coupon_svg):
+    pieces = su.design_pieces(retention_coupon_svg)
+    sample = su.find_piece_by_label(pieces, "Wall Flexure Sample")
+    assert sample is not None
+    # The slot-with-nub hole should be the largest hole (spans most of the
+    # sample's width); the release cut shows up as 2 additional smaller
+    # holes (cavity + severing slot).
+    assert len(sample.holes) >= 3, (
+        f"expected >= 3 holes (slot-with-nub + cavity + severing slot) on the wall "
+        f"flexure sample, found {len(sample.holes)}"
+    )
+
+
+def test_retention_coupon_faceplate_sample_has_release_cut(retention_coupon_svg):
+    pieces = su.design_pieces(retention_coupon_svg)
+    sample = su.find_piece_by_label(pieces, "Faceplate Flexure Sample")
+    assert sample is not None
+    assert len(sample.holes) >= 2, (
+        f"expected >= 2 holes (cavity + severing slot) on the faceplate flexure "
+        f"sample, found {len(sample.holes)}"
+    )

--- a/tests/test_svg_geometry.py
+++ b/tests/test_svg_geometry.py
@@ -276,9 +276,22 @@ def test_drawer_bottom_blank_size():
 
 # DESIGN.md #9 faceplate: "glued to the body front" (not finger-jointed) ->
 # 0 jointed edges both axes.
+#
+# FLAGGED DEVIATION (issue #20, retention iteration 2): the Y-axis nominal
+# below is c.FACEPLATE_DRAWN_WIDTH (150.9 + 2*DRAWER_DETENT_PROTRUDE), not
+# the plain c.FACEPLATE["width"] this test used pre-#20. The faceplate now
+# carries a real cantilever nub that protrudes DRAWER_DETENT_PROTRUDE past
+# each Y edge (see generate_drawers.py's _build_faceplate and DESIGN.md's
+# "Retention (iteration 2)" section) -- svg_utils's bbox-based piece
+# detection has no way to distinguish "a bigger nominal blank" from "a real
+# protruding feature on the same connected piece", so a genuinely larger
+# physical part is the only way to add real interference retention here,
+# and this test's *measurement* (piece.bbox.width) legitimately grew. The
+# tolerance slack (0.5mm) is unchanged from before -- this updates the
+# nominal being measured against, not the rigor of the check.
 def test_faceplate_blank_size():
     piece = _piece(DRAWER_SVG, "faceplate")
-    _assert_band(piece, "Y", piece.bbox.width, c.FACEPLATE["width"], jointed_edges=0)
+    _assert_band(piece, "Y", piece.bbox.width, c.FACEPLATE_DRAWN_WIDTH, jointed_edges=0)
     _assert_band(piece, "Z", piece.bbox.height, c.FACEPLATE["height"], jointed_edges=0)
 
 
@@ -859,5 +872,11 @@ def test_edge_polarity_literals_present():
     assert drawer_src.count('"fFeF"') == 2, "expected drawer Front + Back both using \"fFeF\""
     # Drawer side walls: front/back-mating edges finger, bottom fingers, top open.
     assert '"ffef"' in drawer_src
-    # Drawer Bottom AND Faceplate: plain all around.
-    assert drawer_src.count('"eeee"') == 2, "expected drawer Bottom + Faceplate both using \"eeee\""
+    # Drawer Bottom: plain all around. (Faceplate was also a plain "eeee"
+    # rectangularWall pre-#20; retention iteration 2 gave it a real
+    # protruding nub on both Y edges, which Boxes.py's edge classes can't
+    # express -- generate_drawers.py now hand-draws its whole outer boundary
+    # instead of calling rectangularWall with an edge-type string at all, so
+    # there is no "eeee" literal left to find for it. See the flagged
+    # deviation on test_faceplate_blank_size above for the same root cause.)
+    assert drawer_src.count('"eeee"') == 1, "expected drawer Bottom using \"eeee\""

--- a/tests/test_svg_geometry.py
+++ b/tests/test_svg_geometry.py
@@ -276,22 +276,9 @@ def test_drawer_bottom_blank_size():
 
 # DESIGN.md #9 faceplate: "glued to the body front" (not finger-jointed) ->
 # 0 jointed edges both axes.
-#
-# FLAGGED DEVIATION (issue #20, retention iteration 2): the Y-axis nominal
-# below is c.FACEPLATE_DRAWN_WIDTH (150.9 + 2*DRAWER_DETENT_PROTRUDE), not
-# the plain c.FACEPLATE["width"] this test used pre-#20. The faceplate now
-# carries a real cantilever nub that protrudes DRAWER_DETENT_PROTRUDE past
-# each Y edge (see generate_drawers.py's _build_faceplate and DESIGN.md's
-# "Retention (iteration 2)" section) -- svg_utils's bbox-based piece
-# detection has no way to distinguish "a bigger nominal blank" from "a real
-# protruding feature on the same connected piece", so a genuinely larger
-# physical part is the only way to add real interference retention here,
-# and this test's *measurement* (piece.bbox.width) legitimately grew. The
-# tolerance slack (0.5mm) is unchanged from before -- this updates the
-# nominal being measured against, not the rigor of the check.
 def test_faceplate_blank_size():
     piece = _piece(DRAWER_SVG, "faceplate")
-    _assert_band(piece, "Y", piece.bbox.width, c.FACEPLATE_DRAWN_WIDTH, jointed_edges=0)
+    _assert_band(piece, "Y", piece.bbox.width, c.FACEPLATE["width"], jointed_edges=0)
     _assert_band(piece, "Z", piece.bbox.height, c.FACEPLATE["height"], jointed_edges=0)
 
 
@@ -863,20 +850,39 @@ def test_edge_polarity_literals_present():
     # above it) -- both direction variants.
     assert '["e", "f"]' in shell_src
     assert '["f", "e"]' in shell_src
-    # Bottom panel AND divider: fully captive on all 4 edges.
-    assert shell_src.count('"ffff"') == 2, "expected bottom panel + divider both using \"ffff\""
-    # Horizontal shelf: side edges finger, rear edge plain, front edge finger.
-    assert '["f", "e", "f", "f"]' in shell_src
+    # Divider: fully captive on all 4 edges, still the literal "ffff".
+    # (FLAGGED DEVIATION, issue #20 iteration-3 red-team: the Bottom panel
+    # was ALSO a plain "ffff" pre-iteration-3, fully captive like the
+    # divider -- it no longer is. Two of its four edges now carry a short
+    # PLAIN zone at the catch holes' own X range (mechanism B's catch
+    # holes need real margin at the drawer's worst-case lateral extreme,
+    # which -- verified by rendering -- otherwise clips 1-2 of this edge's
+    # own finger teeth), via a 3-segment CompoundEdge per affected edge
+    # instead of a single "f" character. See CATCH_HOLE_X_PLAIN_LO/HI in
+    # config.py and shell_generator._build_bottom's docstring.)
+    assert shell_src.count('"ffff"') == 1, "expected divider using \"ffff\""
+    assert '[side_edge_left, self.edges["f"], side_edge_right, self.edges["f"]]' in shell_src
+    # Horizontal shelf: side edges finger (same catch-hole plain-zone
+    # deviation as the Bottom panel above), rear edge plain, front edge
+    # finger -- also no longer the literal ["f", "e", "f", "f"] string.
+    assert '[side_edge_left, self.edges["e"], side_edge_right, self.edges["f"]]' in shell_src
 
     # Drawer Front AND Back: side edges finger, bottom fingers, top open.
     assert drawer_src.count('"fFeF"') == 2, "expected drawer Front + Back both using \"fFeF\""
-    # Drawer side walls: front/back-mating edges finger, bottom fingers, top open.
-    assert '"ffef"' in drawer_src
-    # Drawer Bottom: plain all around. (Faceplate was also a plain "eeee"
-    # rectangularWall pre-#20; retention iteration 2 gave it a real
-    # protruding nub on both Y edges, which Boxes.py's edge classes can't
-    # express -- generate_drawers.py now hand-draws its whole outer boundary
-    # instead of calling rectangularWall with an edge-type string at all, so
-    # there is no "eeee" literal left to find for it. See the flagged
-    # deviation on test_faceplate_blank_size above for the same root cause.)
-    assert drawer_src.count('"eeee"') == 1, "expected drawer Bottom using \"eeee\""
+    # Drawer side walls: front/back-mating edges finger, top open. The bottom
+    # edge is no longer the plain "ffef" string (FLAGGED DEVIATION, issue #20
+    # iteration-3 red-team FIX1): it now carries a cantilever flexure nub
+    # near the front end, which -- like the removed iteration-2 faceplate
+    # nub before it -- no stock Boxes.py edge class can express locally, so
+    # the bottom edge is a 3-segment CompoundEdge (finger / purpose-built nub
+    # edge / finger) instead of a single "f" character. The right/top/left
+    # edges are unchanged ("f"/"e"/"f", via self.edges[...] instances rather
+    # than a literal string -- same root cause).
+    assert '[bottom_edge, self.edges["f"], self.edges["e"], self.edges["f"]]' in drawer_src
+    assert 'edges.CompoundEdge(\n            self, ["f", nub_edge, "f"]' in drawer_src
+    # Drawer Bottom: plain all around. (Faceplate is ALSO plain "eeee" again
+    # -- restored to its exact v1 blank, issue #20 iteration-3 FIX1 -- but
+    # since drawer_src now contains a SECOND "eeee" i.e. would make count==2
+    # coincidentally look unchanged from the old pre-iteration-2 assertion,
+    # this is intentionally re-derived from source rather than assumed.)
+    assert drawer_src.count('"eeee"') == 2, "expected drawer Bottom + Faceplate both using \"eeee\""


### PR DESCRIPTION
## Iteration 3: red-team pass fixed a geometrically-impossible mechanism

Three adversarial critics reviewed the iteration-2 retention feature on this
branch. Their confirmed findings, and the fixes, below. **Refs #20.**

### FIX 1 (CRITICAL) — Drawer faceplate detent was geometrically impossible

The faceplate is a Y-Z plate; the drawer travels along X, *normal* to that
plate. A laser-cut edge is square through the material thickness, so a
Z-ramp drawn on a Y-Z part's boundary is never swept by X-axis motion — the
nub could only ever meet the rear-wall opening frame as a **square 0.45mm
interference** (a jam, not a cam). This was never going to work as cut.

**Fix**: faceplates are reverted to their exact v1 blank (150.9 × 53.5,
plain edges, no nub) — `tests/test_svg_geometry.py`'s two flagged
iteration-2 deviations are restored to their exact main-branch versions.
Retention moves entirely into the drawer's two **SIDE walls** (X-Z parts —
their plane contains both the travel axis X and deflection axis Z, so the
ramp genuinely cams):

- One cantilever flexure per side wall, near the front (faceplate) end.
  Nub protrudes DOWN below the side's bottom edge by `DRAWER_DETENT_ENGAGE`
  = 2.2mm (exceeds the drawer's 1.5mm opening vertical clearance by 0.7mm).
- Kinematics: on insertion the nub cams UP over the rear-wall opening's own
  T-thick sill web, rides deflected along the bay floor (bottom drawer) /
  shelf (top drawer), and drops into a **catch hole** cut through that
  panel at the closed position. Catch-hole X derived from the rear wall
  plane, the closed-position reveal, and body length; Y-width covers both
  drawers' full lateral float + margin.
- Beam sized by strain: ε = 3·w·δ/(2·L²), w=2.5, δ=2.2 → L≥23.45mm;
  `DRAWER_DETENT_NUB_TO_ROOT_SPAN` = 26mm gives ε≈1.22%, under plywood's
  ~1.5–2% crack threshold.
- New assembly convention (flagged): both drawer side panels must be
  installed with their flexure end toward the Front panel, not Back.
- **Flagged tension**: sizing the catch hole to the full ~4.9mm/side bay
  float (per spec) puts its edge within ~0.5mm of the bottom panel's/
  shelf's own finger-jointed edge — fixed by giving those edges a
  localized plain zone at the catch hole's X range (verified by rendering:
  without it, the hole clipped 1–2 finger teeth).

### FIX 2 (MAJOR) — Lid detent beam over-stressed

Nub was mid-beam (X=20, root X=29) — 9mm effective root-to-nub span at
1.5mm deflection gave ε≈6.9%, above the crack threshold. Nub moved to the
beam's free end (kept at box X=20, so the lid notch position is
unaffected); root now `LID_DETENT_NUB_TO_ROOT_SPAN`=22mm from the nub
(X=42) → **ε≈1.16%**. New `DETENT_SEVER_CLEARANCE` (1.5mm) keeps the sever
cut clear of the nub's own ramped base so it can't undercut the nub and
leave it bridged to the fixed material outward of it — verified against
the actual drawn geometry (rendered and inspected), not assumed.

### FIX 3 (MAJOR) — Burn/kerf consistency

Every hand-drawn retention shape (nub, notch, drawer-boundary detour) is
now burn-compensated — see `faxbox/detent.py`'s module docstring for the
exact model (holes shrink inward, boundary protrusions grow outward, by
BURN, matching Boxes.py's own corner-only compensation approach since
these shapes have no corner to absorb it otherwise). Previously they were
burn-neutral while their own release cuts (`rectangularHole`) were
compensated, so drawn interference silently drifted from as-cut
interference as BURN changed. One real consequence found: `LID_NOTCH_DEPTH`
3.0mm left only ~0.075mm of margin once burn-compensated — bumped to 3.5mm.
The kerf-test square in `calibration.py` stays burn-neutral (project rule
— it measures kerf, it doesn't compensate for it).

### FIX 4 (CRITICAL) — Test gate holes (mutation testing shipped 3/8 fatal mutations green)

`tests/test_retention.py` rewritten wholesale: existence-first assertions
(a plain rectangle must fail, not vacuously pass), fixed physical bounds
(literals, not config echoes — a wrong tuned value must be catchable),
strain computed from measured SVG dimensions, blank invariants (faceplate
has zero non-axis-aligned boundary segments; drawer side blank height
excluding the nub matches v1).

`tests/conftest.py` now forces this checkout's own `src/` onto the
regeneration subprocess's PYTHONPATH, so running the suite from a git
worktree can't silently test a different checkout's code.

**Mutation gate** (each mutation applied, confirmed RED, then reverted and
confirmed GREEN again):

| # | Mutation | Result |
|---|---|---|
| a | `LID_DETENT_ENGAGE` 1.5→0.5 | RED (2 failed) |
| b | wall nub flipped downward | RED (8 failed) |
| c | lid notch X +5mm | RED (1 failed) |
| d | left wall detent unmirrored | RED (3 failed) |
| e | `DRAWER_DETENT_ENGAGE` 2.2→1.0 | RED (5 failed) |
| f | delete the wall release cut | RED (4 failed) |
| g | remove retention coupon pieces | RED (4 failed) |
| h | `DETENT_RAMP_DEG`→90 (square nub) | RED (21 failed) |
| i | drawer side drawn as plain rectangle | RED (9 failed) |
| j | catch hole Y-width halved | RED (3 failed) |

10/10 mutations caught. Tree verified clean and suite green (189 passed)
after each revert.

### FIX 5 — Coupon rework

`output/retention_coupon.svg` now has 5 pieces: Wall Flexure Sample + Lid
Notch Strip (unchanged mechanism, refit dimensions), and — replacing the
now-invalid faceplate sample — a **Drawer-Side Flexure Sample + Mock Sill
Edge + Mock Floor Strip** (with a real catch hole), exercised by sliding
along the *real* travel axis: cam over the sill edge, ride deflected
across the floor strip, snap into the catch hole. README/calibration.py
add the closed-loop tuning rule (pops free when shaken → raise the
relevant ENGAGE by 0.25 and re-cut; can't slide with one-finger force →
lower by 0.25) — this is the recorded validation for issue #20's force
criteria.

### FIX 6 — Docs

DESIGN.md's retention section is rewritten for the new mechanism
(coordinates, strain numbers, burn policy, grain analysis — both
mechanisms are now grain-favorable, an improvement over the removed
faceplate mechanism which ran across grain), documents the snapped-flexure
failure modes honestly (lid: a loose chunk in the slot channel, never
force it; drawer: loses retention but keeps sliding, not a jam), and
records magnets (6mm discs, press-fit + CA) as the fallback if either
flexure proves too weak in practice. README's cut-day checklist adds a
hard grain-orientation gate and the kerf-coupon → retention-coupon → real
sheets order with the BURN-changed dependency. HANDOFF.md is rewritten
from a stale pre-#20 ledger to the actual current state.

## Ship

- Full suite: **189 passed**, 0 failed, 0 xfail.
- All 21 parts regenerated; sheets fit comfortably within both the
  confirmed 812×508mm bed (Epilog Fusion 32) and the conservative
  609.6×457.2mm fallback `layout.py` still packs to — no overlaps
  (sheet_1: 553.5×355.5mm, sheet_2: 579.3×433.5mm, sheet_3: 547.1×254.2mm).
- Every changed part (walls, lid, drawer sides, faceplate, bottom panel,
  shelf, retention coupon) rendered to PNG and visually verified against
  the intended geometry, including two real defects caught this way and
  fixed: the drawer nub's initial depth calculation (fixed relative to the
  wrong baseline) and the catch holes clipping finger teeth (fixed with a
  localized plain zone on the affected edges).

Not merging — Ben's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvRaq1ibcFkT1fSc7P8E8W
