### PR TITLE
feat: Ponoko export mode (provider abstraction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ fax-machine-box/
 │   ├── generate_drawers.py  # one drawer's 6 pieces (body x5 + faceplate); cut this sheet twice
 │   ├── generate_lids.py     # sliding lid (1 piece)
 │   ├── layout.py            # nests all parts onto bed-sized sheets for cutting
-│   ├── calibration.py       # kerf/ply-thickness coupon + magnet press-fit coupon
-│   └── generate_hardware.py # iteration-2 lid turn-button (1 piece) -> output/hardware.svg
+│   ├── calibration.py       # kerf/ply-thickness coupon + magnet press-fit coupon (+ Ponoko combined coupon)
+│   ├── generate_hardware.py # iteration-2 lid turn-button (1 piece) -> output/hardware.svg
+│   └── ponoko.py            # Ponoko export mode -> output/ponoko/ (see "Ordering from Ponoko")
 ├── tests/                   # pytest harness: geometry, laser-compliance, and layout checks
 ├── docs/service-comparison.md  # laser service comparison + verified NYC Resistor constraints
 ├── DESIGN.md                # canonical geometry — the source of truth for every number
@@ -463,3 +464,60 @@ this checklist is current.
    piece), then dry-fit before gluing anything** — see "Assembly steps"
    above. Don't fit the magnets/turn-button bolts until after glue-up (see
    "Iteration-2 retention hardware" above).
+
+## Ordering from Ponoko
+
+The NYC Resistor path above **remains the default** — nothing about it
+changes unless you explicitly opt in. Ponoko export is an alternate,
+mail-order way to get the same box cut without a laser class or a Brooklyn
+craft night.
+
+**Regenerate for Ponoko** (either command; they're equivalent):
+
+```bash
+.venv/bin/python -m faxbox.ponoko
+# or: FAXBOX_PROVIDER=ponoko .venv/bin/python -m faxbox.layout
+```
+
+This writes `output/ponoko/sheet_1.svg`, `sheet_2.svg`, `sheet_3.svg` (plus
+a reference-only `final_layout.svg` — never upload that one). Differences
+from the NYCR sheets, all verified against Ponoko's own current docs on
+2026-07-07 (source URLs in `src/faxbox/config.py`'s `PONOKO_*` constants):
+
+- **Kerf compensation:** `BURN = 0.10` (half Ponoko's published 0.20mm birch
+  kerf), vs. the NYCR default 0.08.
+- **Sheets re-nested** to fit Ponoko's published 790×384mm max design area
+  for birch plywood (the NYCR sheet 2 at ~549×434mm is too tall for it).
+  Still 3 sheets — price scales with material.
+- **All 22 real parts on the sheets** — the 21 NYCR parts plus the
+  turn-button (standalone `hardware.svg` on the NYCR path) — **plus a
+  self-calibration coupon** (kerf square + 4-hole magnet press-fit gauge
+  row) nested into spare space, since Ponoko has no "cut a coupon on scrap
+  first" step: your first order IS the test cut.
+- **No gray reference text** — Ponoko requires text converted to outlines
+  (it isn't read otherwise), and outlined part names would engrave onto
+  visible faces. Identify parts by size against the "Parts checklist" above
+  (each `<g>` also carries a `data-part` attribute if you open the SVG).
+- Colors are blue=cut / red=vector-engrave — Ponoko's recommended convention,
+  which happens to match this project's own.
+
+**Placing the order:** upload the three `output/ponoko/sheet_*.svg` files at
+ponoko.com, pick **Birch Plywood, 3.2mm** (their 1/8" stock — within this
+design's 3.0–3.4mm tolerance band), one sheet each. Their quote is instant
+at upload. Typical turnaround is roughly ~8 business days production +
+shipping to NYC (check the quote page for current dates).
+
+**Calibrate from the first order** (closes the loop for order #2+):
+
+1. Find the small 110×25mm coupon strip. Measure its square hole with
+   calipers. Its tool path is drawn at exactly 10.0mm (burn-neutral), so:
+   `PONOKO_BURN = (measured − 10.0) / 2` — update it in
+   `src/faxbox/config.py` if it differs from the current 0.10.
+2. Press a real 6mm disc magnet into the 4 gauge holes (5.5 / 5.65 / 5.8 /
+   5.95mm, left to right after the square). Whichever seats snugly sets
+   `MAGNET_PRESS_FIT = MAGNET_DIA − <snuggest diameter>`.
+3. If the first order's finger joints are loose/tight, the kerf-square
+   reading from step 1 is the fix — regenerate and the next order is dialed
+   in. (If joints on the FIRST order don't assemble at all, that's a
+   thickness problem, not kerf — check the delivered ply with calipers
+   against the 3.0–3.4mm band.)

--- a/src/faxbox/calibration.py
+++ b/src/faxbox/calibration.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from boxes import Boxes
 from boxes import edges
 
+from faxbox import config
 from faxbox.config import (
     FINGER_PLAY_RELATIVE,
     BURN,
@@ -296,6 +297,138 @@ def generate_magnet_coupon() -> Path:
     print("  Then set MAGNET_PRESS_FIT = MAGNET_DIA - <snuggest diameter> in config.py and")
     print("  regenerate the shell/drawer SVGs (the magnet holes there ARE burn-compensated, so")
     print("  they need no further correction once MAGNET_PRESS_FIT itself is right).")
+    return output_file
+
+
+
+# =============================================================================
+# Ponoko calibration coupon: kerf square + magnet gauge row, combined into
+# ONE small panel nested onto a real Ponoko sheet (not standalone scrap like
+# the two coupons above) -- see faxbox/ponoko.py and README "Ordering from
+# Ponoko". This makes the FIRST Ponoko order self-calibrating: measure the
+# returned part, update config.PONOKO_BURN / MAGNET_PRESS_FIT, and every
+# subsequent Ponoko order is correct without a separate scrap test cut
+# (unlike NYC Resistor, Ponoko cuts real material sight-unseen -- there is
+# no "cut a coupon on scrap first" step available before the real order).
+# =============================================================================
+
+PONOKO_COUPON_WIDTH = 110.0   # X
+PONOKO_COUPON_HEIGHT = 25.0   # Y
+
+# Same technique as CalibrationCoupon's kerf square above: a RAW ctx square
+# path, exactly 10.0mm on the drawn tool path regardless of the current
+# PONOKO_BURN guess, so measuring the returned physical part reveals
+# Ponoko's REAL per-side kerf: PONOKO_BURN = (measured - 10.0) / 2 (same
+# formula as the NYCR kerf coupon; see that section's docstring for why
+# this one feature must stay burn-NEUTRAL, unlike everything else on this
+# panel).
+PONOKO_KERF_SQUARE_SIZE = 10.0
+
+# Same 4 gauge diameters as MagnetFitCoupon above, burn-COMPENSATED via
+# self.hole() (uses whatever --burn this panel is rendered with, i.e.
+# config.PROVIDERS["ponoko"]["burn"]) -- physically identical to a
+# same-labeled real part hole, exactly like MagnetFitCoupon's own holes.
+PONOKO_MAGNET_DIAMETERS = MAGNET_COUPON_DIAMETERS
+
+_PONOKO_ITEMS = [PONOKO_KERF_SQUARE_SIZE] + list(PONOKO_MAGNET_DIAMETERS)
+_PONOKO_GAP = (PONOKO_COUPON_WIDTH - sum(_PONOKO_ITEMS)) / (len(_PONOKO_ITEMS) + 1)
+PONOKO_COUPON_CENTER_Y = PONOKO_COUPON_HEIGHT / 2
+
+
+def _ponoko_item_centers() -> list[float]:
+    """X centers, left to right: kerf square first, then the 4 magnet
+    gauge holes."""
+    centers = []
+    cursor = _PONOKO_GAP
+    for w in _PONOKO_ITEMS:
+        centers.append(cursor + w / 2)
+        cursor += w + _PONOKO_GAP
+    return centers
+
+
+class PonokoCalibrationCoupon(Boxes):
+    """One small panel: kerf square (burn-neutral) + 4 magnet gauge holes
+    (burn-compensated), all CUT geometry, NO text/labels at all (Ponoko
+    path strips reference labels entirely -- see config.PONOKO_STRIP_LABELS
+    and README "Ordering from Ponoko": Ponoko's file-prep docs require text
+    be converted to outlines or "it will not be read" at all, and nobody
+    wants gauge labels engraved on a real part, so this coupon is drawn
+    without any self.text() call in the first place, rather than relying on
+    a later strip-labels step to remove one)."""
+
+    def __init__(self, provider: str | None = None) -> None:
+        Boxes.__init__(self)
+        self.addSettingsArgs(edges.FingerJointSettings)
+        provider_cfg = config.PROVIDERS[config.resolve_provider(provider)]
+        self.cut_color = provider_cfg["cut_color"]
+
+    def render(self) -> None:
+        self.set_source_color(self.cut_color)
+        centers = _ponoko_item_centers()
+        square_center, hole_centers = centers[0], centers[1:]
+
+        def callback() -> None:
+            # Kerf square: raw ctx path, exactly 10.0mm regardless of burn.
+            half = PONOKO_KERF_SQUARE_SIZE / 2
+            x0, y0 = square_center - half, PONOKO_COUPON_CENTER_Y - half
+            x1, y1 = square_center + half, PONOKO_COUPON_CENTER_Y + half
+            self.ctx.move_to(x0, y0)
+            self.ctx.line_to(x1, y0)
+            self.ctx.line_to(x1, y1)
+            self.ctx.line_to(x0, y1)
+            self.ctx.line_to(x0, y0)
+            self.ctx.stroke()
+            # Magnet gauge holes: burn-compensated, same self.hole() path
+            # every real part magnet hole uses.
+            for cx, d in zip(hole_centers, PONOKO_MAGNET_DIAMETERS):
+                self.hole(cx, PONOKO_COUPON_CENTER_Y, d=d)
+
+        self.rectangularWall(
+            PONOKO_COUPON_WIDTH, PONOKO_COUPON_HEIGHT, "eeee",
+            callback=[callback, None, None, None],
+            move="right", label="",
+        )
+
+
+def generate_ponoko_coupon(provider: str | None = None) -> Path:
+    """Generate the combined Ponoko calibration coupon SVG file (kerf
+    square + magnet gauge row, one small panel, nested onto a real Ponoko
+    sheet by faxbox.ponoko / faxbox.layout.generate_ponoko_layout -- unlike
+    the two standalone NYCR coupons above, this one IS a real ordered part).
+
+    Returns:
+        Path to the generated SVG file.
+    """
+    name = config.resolve_provider(provider)
+    provider_cfg = config.PROVIDERS[name]
+    output_path = Path(provider_cfg["output_dir"])
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_file = output_path / "calibration_coupon.svg"
+
+    coupon = PonokoCalibrationCoupon(provider=name)
+    coupon.parseArgs([
+        "--output", str(output_file),
+        "--thickness", str(MATERIAL_THICKNESS),
+        "--burn", str(provider_cfg["burn"]),
+        "--reference", "0",
+        "--FingerJoint_play", str(FINGER_PLAY_RELATIVE),
+    ])
+
+    coupon.open()
+    coupon.render()
+    data = coupon.close()
+
+    with open(output_file, "wb") as f:
+        f.write(data.getvalue())
+
+    print(f"Generated Ponoko calibration coupon SVG: {output_file.absolute()}")
+    print(f"  Coupon blank: {PONOKO_COUPON_WIDTH}mm x {PONOKO_COUPON_HEIGHT}mm")
+    print(f"  Kerf square: tool path exactly {PONOKO_KERF_SQUARE_SIZE:.1f}mm x "
+          f"{PONOKO_KERF_SQUARE_SIZE:.1f}mm (burn-neutral). Measure the returned "
+          "physical hole with calipers: set config.PONOKO_BURN = (measured - 10.0) / 2.")
+    print(f"  Magnet gauge holes ({', '.join(f'{d:.2f}mm' for d in PONOKO_MAGNET_DIAMETERS)}): "
+          "press a real 6mm disc magnet into each; whichever seats snugly sets "
+          "MAGNET_PRESS_FIT = MAGNET_DIA - <snuggest diameter>.")
     return output_file
 
 

--- a/src/faxbox/config.py
+++ b/src/faxbox/config.py
@@ -8,6 +8,8 @@ Coordinate convention (DESIGN.md): origin at the exterior front-left-bottom
 corner. X+ rearward (length, 12"), Y+ rightward (width, 6.5"), Z+ up (5").
 """
 
+import os
+
 # --- Material & laser -------------------------------------------------------
 
 MATERIAL_THICKNESS = 3.175  # 1/8" plywood, uniform for ALL parts (SPEC)
@@ -260,3 +262,141 @@ ENGRAVE_CENTER = {"x": SHELL_EXT["length"] / 2, "z": 63.5}  # right wall exterio
 # --- Output ------------------------------------------------------------------
 
 OUTPUT_DIR = "output"
+
+# --- Provider abstraction (laser cutting service target, issue #ponoko) -----
+# A "provider" bundles everything that changes when the SAME geometry is
+# ordered from a different laser-cutting service: kerf compensation (BURN),
+# the cut/engrave SVG stroke colors, the sheet size limit to nest within, and
+# whether reference-only part-name labels are kept. Selected either via the
+# FAXBOX_PROVIDER env var or an explicit `provider=` kwarg passed to any
+# faxbox.generate_*()/faxbox.layout function (see resolve_provider() below).
+#
+# DEFAULT_PROVIDER = "nycr" and every PROVIDERS["nycr"] value below is
+# IDENTICAL to this project's pre-existing (pre-provider-abstraction)
+# constants -- BURN, CUT_COLOR, ENGRAVE_COLOR, OUTPUT_DIR -- so the default
+# code path (no env var, no provider arg) is byte-for-byte unchanged. Never
+# add a new PROVIDERS["nycr"] value that isn't already one of this file's
+# pre-existing constants.
+#
+# Ponoko values verified live against Ponoko's own current help/materials
+# pages, 2026-07-07 (see PONOKO_* constants below for each fact + its
+# source URL). Independently re-verified via a second live fetch the same
+# day after an initial research pass returned a color scheme that turned
+# out to be backwards -- see the color-convention comment below.
+
+# --- Ponoko-specific verified constants (birch plywood, 2026-07-07) --------
+
+# Kerf (total width removed by the laser's beam): published directly on
+# Ponoko's birch plywood material page.
+# Source: https://www.ponoko.com/materials/birch-plywood (fetched
+# 2026-07-07: "Kerf Width: 0.20mm").
+PONOKO_KERF = 0.20
+
+# BURN is Boxes.py's PER-SIDE kerf compensation (half the total kerf, since
+# the beam removes material symmetrically from both sides of the drawn
+# line) -- same relationship this project's own kerf coupon uses to derive
+# BURN from a measured cut (calibration.py: "BURN = (measured - 10.0) / 2").
+# Starting value for a first Ponoko order; recalibrate from the kerf-square
+# coupon nested onto the Ponoko sheet (see ponoko.py / README "Ordering
+# from Ponoko") the same way BURN itself is calibrated for NYC Resistor.
+PONOKO_BURN = PONOKO_KERF / 2   # 0.10
+
+# Color convention. IMPORTANT: an initial research pass returned "red=cut,
+# blue=vector-engrave, green=area-engrave" -- this was WRONG (an artifact of
+# stale/confused secondary sources) and was caught by a second, independent
+# live fetch of Ponoko's own current help article before being encoded here.
+# The CURRENT, verified convention is the OPPOSITE for cut/engrave, and uses
+# gray fill (not green) for area engrave, which this project doesn't use
+# (no filled/area-engrave content anywhere in this design):
+#   Blue stroke = cut, Red stroke = line/vector engrave, Gray fill = area engrave.
+# Source: https://help.ponoko.com/en/articles/2688732-how-should-i-specify-laser-actions
+# (fetched live 2026-07-07: "Blue stroke = cutting / Red stroke = line
+# engraving / Gray fill = area engraving"). Corroborated by
+# https://help.ponoko.com/en/articles/2688477-what-design-software-file-type-should-i-use
+# (same fetch date).
+#
+# This happens to be IDENTICAL to this project's own NYC Resistor
+# convention (DESIGN.md: "blue #0000FF = cut, red #FF0000 = engrave") -- a
+# coincidence, not an assumption: both providers' cut/engrave RGB values
+# below are deliberately written as their own named constants (not reused
+# via a shared alias) so a future provider with a genuinely different
+# convention doesn't require restructuring this dict.
+PONOKO_CUT_COLOR = [0.0, 0.0, 1.0]       # blue = cut
+PONOKO_ENGRAVE_COLOR = [1.0, 0.0, 0.0]   # red = line/vector engrave
+
+# Text handling: Ponoko's file-prep docs require text be converted to
+# outlines/paths before upload or "it will not be read" as a laser
+# instruction at all (source: same "what design software / file type"
+# article above). Rather than outline part-name labels into engrave-red
+# vector paths (which would engrave every part name onto the real, visible
+# faceplates/walls -- nobody wants that), this project strips reference
+# labels entirely for the Ponoko path. Also: Ponoko does not hard-reject
+# stray colors (they're user-assignable per-color after upload -- same
+# source), but this project still emits ONLY the two colors above, with NO
+# other stroke/fill color and NO <text> elements, to keep the uploaded file
+# unambiguous.
+PONOKO_STRIP_LABELS = True
+
+# Sheet size to nest within. Ponoko publishes two different numbers for
+# birch plywood: a raw maximum SHEET size, and a smaller maximum DESIGN
+# (workable) area within that sheet -- the gap between them is Ponoko's own
+# sheet-edge margin, so designs must nest within the smaller (workable)
+# figure, not the raw sheet size.
+#   Raw max sheet size: 795.00mm x 395.00mm.
+#   Source: https://www.ponoko.com/materials/birch-plywood (fetched
+#   2026-07-07: "Maximum Sheet Size: 795.00 x 395.00mm").
+#   Max DESIGN/part size (this project's "P3"-equivalent workable area,
+#   applies to birch plywood as one of the "100+ materials" at this size):
+#   790mm x 384mm.
+#   Source: https://help.ponoko.com/en/articles/2688726-what-size-can-i-make-my-part-what-material-sizes-are-available
+#   (fetched 2026-07-07: "For 100+ materials the maximum material sheet
+#   size is 31.1\" x 15.1\" / 790mm x 384mm").
+# This project nests within the smaller (790 x 384) figure.
+PONOKO_SHEET_WIDTH = 790.0
+PONOKO_SHEET_HEIGHT = 384.0
+
+# Minimum gap Ponoko wants between design elements: "at least 0.040\" (1mm)
+# between elements," parts under 6mm can fall through the bed.
+# Source: https://help.ponoko.com/en/articles/2688741-how-do-i-design-for-highest-quality
+# (fetched 2026-07-07). This project's existing MARGIN_MM=10 /
+# SPACING_MM=5 (layout.py) are already well over this minimum, so the
+# Ponoko nesting pass reuses those same two constants rather than adding a
+# separate, looser pair.
+
+PONOKO_OUTPUT_DIR = f"{OUTPUT_DIR}/ponoko"
+
+PROVIDERS = {
+    "nycr": {
+        "burn": BURN,                    # 0.08, this file's pre-existing default
+        "cut_color": CUT_COLOR,          # blue, pre-existing
+        "engrave_color": ENGRAVE_COLOR,  # red, pre-existing
+        "strip_labels": False,           # keep gray reference-only part labels
+        "output_dir": OUTPUT_DIR,        # "output", pre-existing
+    },
+    "ponoko": {
+        "burn": PONOKO_BURN,
+        "cut_color": PONOKO_CUT_COLOR,
+        "engrave_color": PONOKO_ENGRAVE_COLOR,
+        "strip_labels": PONOKO_STRIP_LABELS,
+        "output_dir": PONOKO_OUTPUT_DIR,
+        "sheet_width": PONOKO_SHEET_WIDTH,
+        "sheet_height": PONOKO_SHEET_HEIGHT,
+    },
+}
+
+DEFAULT_PROVIDER = "nycr"
+
+
+def resolve_provider(explicit: str | None = None) -> str:
+    """Resolve which PROVIDERS entry to use: an explicit `provider=` kwarg
+    wins, then the FAXBOX_PROVIDER env var, then DEFAULT_PROVIDER ("nycr").
+
+    Every faxbox.generate_*() function and faxbox.layout.generate_layout()-
+    family function takes an optional `provider` kwarg that funnels through
+    this, so calling any of them with no arguments and no FAXBOX_PROVIDER
+    set reproduces this project's original (pre-provider-abstraction)
+    behavior exactly.
+    """
+    if explicit:
+        return explicit
+    return os.environ.get("FAXBOX_PROVIDER", DEFAULT_PROVIDER)

--- a/src/faxbox/generate_drawers.py
+++ b/src/faxbox/generate_drawers.py
@@ -27,18 +27,15 @@ from pathlib import Path
 from boxes import Boxes
 from boxes import edges
 
+from faxbox import config
 from faxbox.config import (
     FINGER_PLAY_RELATIVE,
-    BURN,
-    CUT_COLOR,
     DRAWER_BODY,
     DRAWER_GRIP_SLOT,
-    ENGRAVE_COLOR,
     FACEPLATE,
     MAGNET_HOLE_DIA,
     MAGNET_Y_OFFSET,
     MATERIAL_THICKNESS,
-    OUTPUT_DIR,
 )
 
 T = MATERIAL_THICKNESS
@@ -75,9 +72,14 @@ class DrawerBox(Boxes):
     """One drawer's 6 pieces: Front, Back, Left Side, Right Side, Bottom,
     Faceplate (DESIGN.md #9)."""
 
-    def __init__(self) -> None:
+    def __init__(self, provider: str | None = None) -> None:
         Boxes.__init__(self)
         self.addSettingsArgs(edges.FingerJointSettings)
+        # Provider abstraction (config.PROVIDERS) -- see shell_generator.py's
+        # OuterShell.__init__ for the full rationale. Defaults to "nycr".
+        provider_cfg = config.PROVIDERS[config.resolve_provider(provider)]
+        self.cut_color = provider_cfg["cut_color"]
+        self.engrave_color = provider_cfg["engrave_color"]
 
     # -- grip slot: same formula for Front and Faceplate, so they align ---
     # (DESIGN.md: "slot top edge 8.0 below the part's top edge"). Each
@@ -112,7 +114,7 @@ class DrawerBox(Boxes):
         gap = 1.0
         x0, x1 = cx - width / 2, cx + width / 2
         y0, y1 = cy - height / 2, cy + height / 2
-        self.set_source_color(ENGRAVE_COLOR)
+        self.set_source_color(self.engrave_color)
         for (ax, ay), (bx, by) in (
             ((x0 + gap, y0), (x1 - gap, y0)),
             ((x1, y0 + gap), (x1, y1 - gap)),
@@ -122,7 +124,7 @@ class DrawerBox(Boxes):
             self.ctx.move_to(ax, ay)
             self.ctx.line_to(bx, by)
             self.ctx.stroke()
-        self.set_source_color(CUT_COLOR)
+        self.set_source_color(self.cut_color)
 
     # -- pieces ---------------------------------------------------------
 
@@ -215,7 +217,7 @@ class DrawerBox(Boxes):
     def render(self) -> None:
         """Render all 6 pieces, laid out in a single row (move='right'
         throughout) so bounding boxes never overlap."""
-        self.set_source_color(CUT_COLOR)
+        self.set_source_color(self.cut_color)
 
         self._build_front()
         self._build_back()
@@ -225,21 +227,27 @@ class DrawerBox(Boxes):
         self._build_faceplate()
 
 
-def generate_drawer() -> Path:
+def generate_drawer(provider: str | None = None) -> Path:
     """Generate a drawer SVG file (one drawer's 6 pieces; cut twice).
+
+    `provider` selects a faxbox.config.PROVIDERS entry (see
+    shell_generator.generate_shell's docstring). Passing nothing reproduces
+    the original output/drawer.svg exactly.
 
     Returns:
         Path to the generated SVG file.
     """
-    output_path = Path(OUTPUT_DIR)
+    name = config.resolve_provider(provider)
+    provider_cfg = config.PROVIDERS[name]
+    output_path = Path(provider_cfg["output_dir"])
     output_path.mkdir(parents=True, exist_ok=True)
     output_file = output_path / "drawer.svg"
 
-    drawer = DrawerBox()
+    drawer = DrawerBox(provider=name)
     drawer.parseArgs([
         "--output", str(output_file),
         "--thickness", str(MATERIAL_THICKNESS),
-        "--burn", str(BURN),
+        "--burn", str(provider_cfg["burn"]),
         "--reference", "0",
         "--FingerJoint_play", str(FINGER_PLAY_RELATIVE),
     ])

--- a/src/faxbox/generate_hardware.py
+++ b/src/faxbox/generate_hardware.py
@@ -29,13 +29,11 @@ from pathlib import Path
 from boxes import Boxes
 from boxes import edges
 
+from faxbox import config
 from faxbox.calibration import LABEL_GRAY
 from faxbox.config import (
     FINGER_PLAY_RELATIVE,
-    BURN,
-    CUT_COLOR,
     MATERIAL_THICKNESS,
-    OUTPUT_DIR,
     TURN_BUTTON,
 )
 
@@ -57,9 +55,13 @@ assert abs(CAP_RADIUS - PIVOT_FROM_BLUNT_END) < 1e-9, (
 class TurnButton(Boxes):
     """One rounded paddle/stadium turn-button, pivot hole in the blunt end."""
 
-    def __init__(self) -> None:
+    def __init__(self, provider: str | None = None) -> None:
         Boxes.__init__(self)
         self.addSettingsArgs(edges.FingerJointSettings)
+        # Provider abstraction (config.PROVIDERS) -- see shell_generator.py's
+        # OuterShell.__init__ for the full rationale. Defaults to "nycr".
+        provider_cfg = config.PROVIDERS[config.resolve_provider(provider)]
+        self.cut_color = provider_cfg["cut_color"]
 
     def _build_button(self, label: str) -> None:
         """Draw one button: pivot hole first (in the pristine, untranslated
@@ -97,25 +99,31 @@ class TurnButton(Boxes):
     def render(self) -> None:
         """Render the single button (REV.B: one front-wall button, not two
         side-wall ones -- see module docstring)."""
-        self.set_source_color(CUT_COLOR)
+        self.set_source_color(self.cut_color)
         self._build_button("Turn Button")
 
 
-def generate_hardware() -> Path:
+def generate_hardware(provider: str | None = None) -> Path:
     """Generate the turn-button hardware SVG file.
+
+    `provider` selects a faxbox.config.PROVIDERS entry (see
+    shell_generator.generate_shell's docstring). Passing nothing reproduces
+    the original output/hardware.svg exactly.
 
     Returns:
         Path to the generated SVG file.
     """
-    output_path = Path(OUTPUT_DIR)
+    name = config.resolve_provider(provider)
+    provider_cfg = config.PROVIDERS[name]
+    output_path = Path(provider_cfg["output_dir"])
     output_path.mkdir(parents=True, exist_ok=True)
     output_file = output_path / "hardware.svg"
 
-    hardware = TurnButton()
+    hardware = TurnButton(provider=name)
     hardware.parseArgs([
         "--output", str(output_file),
         "--thickness", str(MATERIAL_THICKNESS),
-        "--burn", str(BURN),
+        "--burn", str(provider_cfg["burn"]),
         "--reference", "0",
         "--FingerJoint_play", str(FINGER_PLAY_RELATIVE),
     ])

--- a/src/faxbox/generate_lids.py
+++ b/src/faxbox/generate_lids.py
@@ -15,13 +15,11 @@ from pathlib import Path
 from boxes import Boxes
 from boxes import edges
 
+from faxbox import config
 from faxbox.config import (
     FINGER_PLAY_RELATIVE,
-    BURN,
-    CUT_COLOR,
     LID_GRIP_SLOT,
     MATERIAL_THICKNESS,
-    OUTPUT_DIR,
     SLIDING_LID,
 )
 
@@ -29,13 +27,17 @@ from faxbox.config import (
 class LidGenerator(Boxes):
     """Generate the sliding lid panel for the fax machine box."""
 
-    def __init__(self) -> None:
+    def __init__(self, provider: str | None = None) -> None:
         Boxes.__init__(self)
         self.addSettingsArgs(edges.FingerJointSettings)
+        # Provider abstraction (config.PROVIDERS) -- see shell_generator.py's
+        # OuterShell.__init__ for the full rationale. Defaults to "nycr".
+        provider_cfg = config.PROVIDERS[config.resolve_provider(provider)]
+        self.cut_color = provider_cfg["cut_color"]
 
     def render(self) -> None:
         """Render the sliding lid piece."""
-        self.set_source_color(CUT_COLOR)
+        self.set_source_color(self.cut_color)
 
         length = SLIDING_LID["length"]
         width = SLIDING_LID["width"]
@@ -54,22 +56,28 @@ class LidGenerator(Boxes):
         )
 
 
-def generate_lids() -> Path:
+def generate_lids(provider: str | None = None) -> Path:
     """Generate the lids SVG file.
+
+    `provider` selects a faxbox.config.PROVIDERS entry (see
+    shell_generator.generate_shell's docstring). Passing nothing reproduces
+    the original output/lids.svg exactly.
 
     Returns:
         Path to the generated SVG file.
     """
-    output_path = Path(OUTPUT_DIR)
+    name = config.resolve_provider(provider)
+    provider_cfg = config.PROVIDERS[name]
+    output_path = Path(provider_cfg["output_dir"])
     output_path.mkdir(parents=True, exist_ok=True)
 
     output_file = output_path / "lids.svg"
 
-    lids = LidGenerator()
+    lids = LidGenerator(provider=name)
     lids.parseArgs([
         "--output", str(output_file),
         "--thickness", str(MATERIAL_THICKNESS),
-        "--burn", str(BURN),
+        "--burn", str(provider_cfg["burn"]),
         "--reference", "0",
         "--FingerJoint_play", str(FINGER_PLAY_RELATIVE),
     ])

--- a/src/faxbox/layout.py
+++ b/src/faxbox/layout.py
@@ -38,6 +38,7 @@ from xml.sax.saxutils import escape, quoteattr
 
 import svgpathtools
 
+from faxbox import config
 from faxbox.config import OUTPUT_DIR
 
 SVG_NS = "{http://www.w3.org/2000/svg}"
@@ -95,8 +96,17 @@ class Placement:
     y: float
 
 
-def _load_pieces(svg_path: Path, source: str) -> list[Piece]:
-    """Read every top-level <g> (one per Boxes.py part) from svg_path."""
+def _load_pieces(svg_path: Path, source: str, strip_labels: bool = False) -> list[Piece]:
+    """Read every top-level <g> (one per Boxes.py part) from svg_path.
+
+    `strip_labels`: when True, the piece's `<text>` label (if any) is used
+    only to compute a human-readable `label` for identification, and is
+    NOT carried into the Piece's text_attrib/text_content -- so
+    _emit_piece_group later emits no <text> element at all for this piece.
+    Used by the Ponoko path (config.PONOKO_STRIP_LABELS), which strips
+    reference labels entirely rather than re-coloring them gray like the
+    default NYCR path.
+    """
     root = ET.parse(svg_path).getroot()
     pieces: list[Piece] = []
     for g in root.findall(f"{SVG_NS}g"):
@@ -126,8 +136,8 @@ def _load_pieces(svg_path: Path, source: str) -> list[Piece]:
                 ymin=ymin,
                 group_style=g.get("style", ""),
                 svg_paths=svg_paths,
-                text_attrib=dict(text_el.attrib) if text_el is not None else None,
-                text_content=text_el.text if text_el is not None else None,
+                text_attrib=None if strip_labels or text_el is None else dict(text_el.attrib),
+                text_content=None if strip_labels or text_el is None else text_el.text,
             )
         )
     return pieces
@@ -135,21 +145,32 @@ def _load_pieces(svg_path: Path, source: str) -> list[Piece]:
 
 # --- Packing --------------------------------------------------------------
 
-def _pack_pieces(pieces: list[Piece]) -> list[list[Placement]]:
+def _pack_pieces(
+    pieces: list[Piece],
+    sheet_width: float = SHEET_WIDTH_MM,
+    sheet_height: float = SHEET_HEIGHT_MM,
+    margin: float = MARGIN_MM,
+    spacing: float = SPACING_MM,
+) -> list[list[Placement]]:
     """Shelf (row) packer. See module docstring for the algorithm.
+
+    `sheet_width`/`sheet_height`/`margin`/`spacing` default to this
+    project's NYC Resistor planning constants; the Ponoko path passes
+    config.PROVIDERS["ponoko"]'s sheet limit instead (same margin/spacing,
+    which are already well over Ponoko's published ~1mm minimum).
 
     Returns one list of Placement per sheet, in sheet order. Raises
     ValueError if any single piece is too big to ever fit a sheet.
     """
-    usable_w = SHEET_WIDTH_MM - 2 * MARGIN_MM
-    usable_h = SHEET_HEIGHT_MM - 2 * MARGIN_MM
+    usable_w = sheet_width - 2 * margin
+    usable_h = sheet_height - 2 * margin
 
     for p in pieces:
         if p.width > usable_w + 1e-6 or p.height > usable_h + 1e-6:
             raise ValueError(
                 f"{p.source}: {p.label!r} ({p.width:.1f}x{p.height:.1f}mm) does not fit "
-                f"within a single {SHEET_WIDTH_MM:.1f}x{SHEET_HEIGHT_MM:.1f}mm sheet "
-                f"(usable {usable_w:.1f}x{usable_h:.1f}mm after {MARGIN_MM}mm margins) -- "
+                f"within a single {sheet_width:.1f}x{sheet_height:.1f}mm sheet "
+                f"(usable {usable_w:.1f}x{usable_h:.1f}mm after {margin}mm margins) -- "
                 f"bed size too small for this part"
             )
 
@@ -166,7 +187,7 @@ def _pack_pieces(pieces: list[Piece]) -> list[list[Placement]]:
             for hi, shelf in enumerate(shelves):
                 if shelf["height"] + 1e-6 < piece.height:
                     continue
-                gap = SPACING_MM if shelf["items"] else 0.0
+                gap = spacing if shelf["items"] else 0.0
                 if shelf["x_cursor"] + gap + piece.width > usable_w + 1e-6:
                     continue
                 if best is None or shelf["height"] < sheets[best[0]][best[1]]["height"]:
@@ -177,7 +198,7 @@ def _pack_pieces(pieces: list[Piece]) -> list[list[Placement]]:
             # room on the current (last) sheet before starting a new sheet.
             si = len(sheets) - 1
             shelves = sheets[si]
-            y_cursor = sum(s["height"] + SPACING_MM for s in shelves)
+            y_cursor = sum(s["height"] + spacing for s in shelves)
             if y_cursor + piece.height > usable_h + 1e-6:
                 sheets.append([])
                 si = len(sheets) - 1
@@ -188,20 +209,20 @@ def _pack_pieces(pieces: list[Piece]) -> list[list[Placement]]:
 
         si, hi = best
         shelf = sheets[si][hi]
-        gap = SPACING_MM if shelf["items"] else 0.0
+        gap = spacing if shelf["items"] else 0.0
         x = shelf["x_cursor"] + gap
         shelf["x_cursor"] = x + piece.width
-        shelf["items"].append(Placement(piece=piece, x=MARGIN_MM + x, y=MARGIN_MM + shelf["y"]))
+        shelf["items"].append(Placement(piece=piece, x=margin + x, y=margin + shelf["y"]))
 
     return [[placement for shelf in shelves for placement in shelf["items"]] for shelves in sheets]
 
 
-def _sheet_content_bounds(placements: list[Placement]) -> tuple[float, float]:
+def _sheet_content_bounds(placements: list[Placement], margin: float = MARGIN_MM) -> tuple[float, float]:
     """Sheet dimensions trimmed to just fit the placed content plus the far
     margin (so real material bought for cutting isn't bigger than needed)."""
     max_x = max(p.x + p.piece.width for p in placements)
     max_y = max(p.y + p.piece.height for p in placements)
-    return max_x + MARGIN_MM, max_y + MARGIN_MM
+    return max_x + margin, max_y + margin
 
 
 # --- SVG emission ------------------------------------------------------------
@@ -274,21 +295,24 @@ def _emit_piece_group(piece: Piece, target_x: float, target_y: float, group_id: 
 
 
 def _write_sheet_svg(
-    placements: list[Placement], width: float, height: float, output_path: Path, sheet_number: int, total_sheets: int
+    placements: list[Placement],
+    width: float,
+    height: float,
+    output_path: Path,
+    sheet_number: int,
+    total_sheets: int,
+    header_comment: str | None = None,
+    title: str | None = None,
 ) -> None:
     groups = [
         _emit_piece_group(placement.piece, placement.x, placement.y, f"sheet{sheet_number}-p{i}")
         for i, placement in enumerate(placements)
     ]
     body = "\n".join(groups)
-    # Note: XML comments may not contain "--", so the comment body below
-    # uses single hyphens only (unlike the surrounding Python docstrings).
-    svg = f"""<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg"
-    width="{width:.2f}mm" height="{height:.2f}mm"
-    viewBox="0 0 {width:.2f} {height:.2f}">
-<!--
-Fax Machine Box - Sheet {sheet_number} of {total_sheets}. Ready for laser
+    if header_comment is None:
+        # Note: XML comments may not contain "--", so the comment body below
+        # uses single hyphens only (unlike the surrounding Python docstrings).
+        header_comment = f"""Fax Machine Box - Sheet {sheet_number} of {total_sheets}. Ready for laser
 cutting (NYC Resistor or any service with an equal or larger bed).
 Material: 3.175mm (1/8 inch) plywood.
 
@@ -297,9 +321,17 @@ Color coding: Blue (#0000FF) = cut, Red (#FF0000) = engrave. The gray
 identify the part for a human; it carries data-purpose="reference-label" on
 its <text> element and must NOT be mapped to any cut or engrave operation in
 the laser driver.
-Margins: {MARGIN_MM:.0f}mm from sheet edge; {SPACING_MM:.0f}mm between parts.
+Margins: {MARGIN_MM:.0f}mm from sheet edge; {SPACING_MM:.0f}mm between parts."""
+    if title is None:
+        title = f"Fax Machine Box - Sheet {sheet_number} of {total_sheets}"
+    svg = f"""<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+    width="{width:.2f}mm" height="{height:.2f}mm"
+    viewBox="0 0 {width:.2f} {height:.2f}">
+<!--
+{header_comment}
 -->
-<title>Fax Machine Box - Sheet {sheet_number} of {total_sheets}</title>
+<title>{title}</title>
 {body}
 </svg>
 """
@@ -437,5 +469,134 @@ def generate_layout() -> list[Path]:
     return sheet_paths
 
 
+# --- Ponoko export mode (additive; never touches the NYCR path above) --------
+
+# 21 NYCR parts (8 shell + 12 drawer + 1 lid) + the turn-button hardware
+# piece, which the NYCR default path deliberately keeps standalone (see
+# generate_layout's docstring / DESIGN.md section B) but the Ponoko path
+# nests like every other part, since a single Ponoko order should carry
+# every laser-cut piece the box needs.
+PONOKO_EXPECTED_PARTS = 22
+# The combined kerf-square + magnet-gauge-row self-calibration coupon
+# (faxbox.calibration.generate_ponoko_coupon) -- see README "Ordering from
+# Ponoko" for why Ponoko orders need this nested onto the real sheet rather
+# than cut on scrap first (unlike NYC Resistor, there is no walk-up scrap
+# test cut available before a Ponoko order ships).
+PONOKO_EXPECTED_COUPONS = 1
+
+
+def _ponoko_header_comment(sheet_number: int, total_sheets: int) -> str:
+    # Note: XML comments may not contain "--" (same constraint documented on
+    # _write_sheet_svg's default header comment), so the text below uses
+    # single hyphens and colons only.
+    return f"""Fax Machine Box - PONOKO order - Sheet {sheet_number} of {total_sheets}.
+Material: 3.2mm birch plywood (Ponoko's nominal size for 1/8in stock).
+
+Verified against Ponoko's own current help pages (2026-07-07):
+  Color coding: Blue (#0000FF) = cut, Red (#FF0000) = line/vector engrave.
+  Source: https://help.ponoko.com/en/articles/2688732-how-should-i-specify-laser-actions
+  Kerf 0.20mm, so BURN = 0.10mm (this project's per-side kerf compensation).
+  Source: https://www.ponoko.com/materials/birch-plywood
+  Sheet nested within the 790mm x 384mm max DESIGN area (not the 795x395mm
+  raw max sheet size; the gap is Ponoko's own sheet-edge margin).
+  Source: https://help.ponoko.com/en/articles/2688726-what-size-can-i-make-my-part-what-material-sizes-are-available
+
+No reference-only labels on this sheet: Ponoko's file-prep docs require
+text be outlined/converted before upload or it "will not be read" as a
+laser instruction at all (source: https://help.ponoko.com/en/articles/2688477-what-design-software-file-type-should-i-use).
+Rather than outline part names into visible engrave-red paths, this sheet
+omits them entirely; see README "Ordering from Ponoko" for part
+identification instead.
+Margins: {MARGIN_MM:.0f}mm from sheet edge; {SPACING_MM:.0f}mm between parts
+(Ponoko's own published minimum is ~1mm; kept at this project's existing,
+more conservative NYCR values)."""
+
+
+def generate_ponoko_layout(provider: str | None = None) -> list[Path]:
+    """Regenerate every part with Ponoko's provider settings (kerf-derived
+    BURN, Ponoko's cut/vector-engrave colors, no reference labels -- see
+    config.PROVIDERS["ponoko"]) and re-nest ALL of them -- the 21 NYCR parts,
+    the turn-button hardware piece, and a small self-calibration coupon
+    (kerf square + magnet press-fit gauge row) -- onto sheets sized within
+    Ponoko's published birch-plywood workable area. Output:
+    config.PROVIDERS["ponoko"]["output_dir"] (output/ponoko/).
+
+    This is entirely additive: it never touches output/*.svg (the NYCR
+    default path generate_layout() produces) and is only invoked via
+    faxbox.ponoko or FAXBOX_PROVIDER=ponoko.
+
+    Returns the list of sheet_N.svg paths, in order.
+    """
+    name = config.resolve_provider(provider)
+    if name != "ponoko":
+        raise ValueError(f"generate_ponoko_layout only supports provider='ponoko', got {name!r}")
+    provider_cfg = config.PROVIDERS[name]
+    output_path = Path(provider_cfg["output_dir"])
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Regenerate every ponoko-flavored source SVG. Imported here (not at
+    # module level) purely to keep this Ponoko-only dependency scoped to
+    # where it's used -- these modules only import faxbox.config, so there
+    # is no import cycle either way.
+    from faxbox import calibration, generate_drawers, generate_hardware, generate_lids, shell_generator
+
+    shell_svg = shell_generator.generate_shell(provider=name)
+    drawer_svg = generate_drawers.generate_drawer(provider=name)
+    lids_svg = generate_lids.generate_lids(provider=name)
+    hardware_svg = generate_hardware.generate_hardware(provider=name)
+    coupon_svg = calibration.generate_ponoko_coupon(provider=name)
+
+    strip = provider_cfg["strip_labels"]
+    pieces: list[Piece] = []
+    pieces += _load_pieces(shell_svg, "Shell", strip_labels=strip)
+    pieces += _load_pieces(drawer_svg, "Drawer 1", strip_labels=strip)
+    pieces += _load_pieces(drawer_svg, "Drawer 2", strip_labels=strip)
+    pieces += _load_pieces(lids_svg, "Lid", strip_labels=strip)
+    pieces += _load_pieces(hardware_svg, "Hardware", strip_labels=strip)
+    pieces += _load_pieces(coupon_svg, "Calibration", strip_labels=strip)
+
+    sheets = _pack_pieces(
+        pieces,
+        sheet_width=provider_cfg["sheet_width"],
+        sheet_height=provider_cfg["sheet_height"],
+    )
+
+    sheet_paths: list[Path] = []
+    sheet_dims: list[tuple[float, float]] = []
+    for i, placements in enumerate(sheets, start=1):
+        width, height = _sheet_content_bounds(placements)
+        sheet_path = output_path / f"sheet_{i}.svg"
+        _write_sheet_svg(
+            placements, width, height, sheet_path, i, len(sheets),
+            header_comment=_ponoko_header_comment(i, len(sheets)),
+            title=f"Fax Machine Box - PONOKO order - Sheet {i} of {len(sheets)}",
+        )
+        sheet_paths.append(sheet_path)
+        sheet_dims.append((width, height))
+
+    _write_reference_layout(sheets, sheet_dims, output_path / "final_layout.svg")
+
+    total_parts = sum(len(p) for p in sheets)
+    print(f"Generated {len(sheets)} Ponoko sheet(s) in {output_path.absolute()}:")
+    for path, (w, h) in zip(sheet_paths, sheet_dims):
+        print(f"  {path.name}: {w:.1f}mm x {h:.1f}mm")
+    print(
+        f"Total parts placed: {total_parts} (expected "
+        f"{PONOKO_EXPECTED_PARTS + PONOKO_EXPECTED_COUPONS}: {PONOKO_EXPECTED_PARTS} real parts "
+        "[21 NYCR parts + 1 turn button] + "
+        f"{PONOKO_EXPECTED_COUPONS} self-calibration coupon)"
+    )
+    print(
+        f"Ponoko sheet limit used: {provider_cfg['sheet_width']:.1f}mm x "
+        f"{provider_cfg['sheet_height']:.1f}mm (verified 2026-07-07, see config.py PONOKO_* constants)"
+    )
+    print(f"Reference-only combined view: {(output_path / 'final_layout.svg').absolute()}")
+
+    return sheet_paths
+
+
 if __name__ == "__main__":
-    generate_layout()
+    if config.resolve_provider() == "ponoko":
+        generate_ponoko_layout()
+    else:
+        generate_layout()

--- a/src/faxbox/ponoko.py
+++ b/src/faxbox/ponoko.py
@@ -1,0 +1,32 @@
+"""Convenience entry point for the Ponoko export mode: regenerate every
+part with Ponoko's provider settings and re-nest them onto Ponoko-sized
+sheets, in one command.
+
+    .venv/bin/python -m faxbox.ponoko
+
+is equivalent to:
+
+    FAXBOX_PROVIDER=ponoko .venv/bin/python -m faxbox.layout
+
+(the provider abstraction itself lives in faxbox.config.PROVIDERS and
+faxbox.layout.generate_ponoko_layout -- this module is purely a friendlier
+name for the same call, since every OTHER stage of this project already has
+its own dedicated module (shell_generator, generate_drawers, generate_lids,
+layout), and generate_ponoko_layout already regenerates all of its own
+ponoko-flavored source SVGs internally).
+
+Output: output/ponoko/ (sheet_1.svg, sheet_2.svg, ..., final_layout.svg,
+plus the intermediate outer_shell.svg / drawer.svg / lids.svg / hardware.svg
+/ calibration_coupon.svg). The default NYC Resistor path (output/*.svg,
+`python -m faxbox.layout` with no env var) is never touched by this module.
+"""
+
+from faxbox.layout import generate_ponoko_layout
+
+
+def main() -> None:
+    generate_ponoko_layout(provider="ponoko")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/faxbox/shell_generator.py
+++ b/src/faxbox/shell_generator.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from boxes import Boxes
 from boxes import edges
 
+from faxbox import config
 from faxbox.config import (
     FINGER_PLAY_RELATIVE,
     BAY_LENGTH,
@@ -27,13 +28,10 @@ from faxbox.config import (
     BAY_X1,
     BOTTOM_OPENING_Z0,
     BOTTOM_OPENING_Z1,
-    BURN,
-    CUT_COLOR,
     DIVIDER_HEIGHT,
     DIVIDER_X0,
     DIVIDER_X1,
     ENGRAVE_CENTER,
-    ENGRAVE_COLOR,
     ENGRAVE_FONT_SPACING,
     ENGRAVE_PIXEL_SIZE,
     ENGRAVE_TEXT,
@@ -52,7 +50,6 @@ from faxbox.config import (
     MATERIAL_THICKNESS,
     OPENING_HEIGHT,
     OPENING_WIDTH,
-    OUTPUT_DIR,
     SHELF_Z0,
     TOP_OPENING_Z0,
     TOP_OPENING_Z1,
@@ -113,9 +110,18 @@ SHELF_MID_Z = SHELF_Z0 + T / 2
 class OuterShell(Boxes):
     """Outer shell: bottom, 4 walls, divider, shelf, fixed top panel."""
 
-    def __init__(self) -> None:
+    def __init__(self, provider: str | None = None) -> None:
         Boxes.__init__(self)
         self.addSettingsArgs(edges.FingerJointSettings)
+        # Provider abstraction (config.PROVIDERS): which cut/engrave colors
+        # this instance draws with. Defaults to "nycr" (this project's
+        # original hardcoded CUT_COLOR/ENGRAVE_COLOR), so an un-parameterized
+        # OuterShell() is byte-for-byte identical to pre-provider-abstraction
+        # behavior. BURN itself is NOT threaded through here -- it flows via
+        # the --burn CLI arg in generate_shell() below, same as always.
+        provider_cfg = config.PROVIDERS[config.resolve_provider(provider)]
+        self.cut_color = provider_cfg["cut_color"]
+        self.engrave_color = provider_cfg["engrave_color"]
 
     # -- pixel-font engraving (ctx.fill() is not implemented by Boxes.py;
     # engrave by stroking closed pixel-square paths in ENGRAVE_COLOR) -------
@@ -153,12 +159,12 @@ class OuterShell(Boxes):
 
     def draw_pixel_text(self, text: str, x: float, y: float, pixel_size: float = ENGRAVE_PIXEL_SIZE) -> None:
         """Draw text using the pixel font in the engraving (red) color."""
-        self.set_source_color(ENGRAVE_COLOR)
+        self.set_source_color(self.engrave_color)
         current_x = x
         for char in text.upper():
             width = self.draw_pixel_char(char, current_x, y, pixel_size)
             current_x += width
-        self.set_source_color(CUT_COLOR)
+        self.set_source_color(self.cut_color)
 
     def _engrave_fax_machine(self) -> None:
         """"FAX MACHINE" pixel text, centered per DESIGN.md's ENGRAVE_CENTER
@@ -387,7 +393,7 @@ class OuterShell(Boxes):
     def render(self) -> None:
         """Render all 8 shell pieces, laid out in a single row (move=
         'right' throughout) so bounding boxes never overlap."""
-        self.set_source_color(CUT_COLOR)
+        self.set_source_color(self.cut_color)
 
         self._build_bottom()
         self._build_side_wall(mirror=False, label="Right Wall", engrave=True)
@@ -399,17 +405,25 @@ class OuterShell(Boxes):
         self._build_top_panel()
 
 
-def generate_shell() -> Path:
-    """Generate outer shell SVG file."""
-    output_path = Path(OUTPUT_DIR)
+def generate_shell(provider: str | None = None) -> Path:
+    """Generate outer shell SVG file.
+
+    `provider` selects a faxbox.config.PROVIDERS entry (falls back to the
+    FAXBOX_PROVIDER env var, then "nycr" -- see config.resolve_provider).
+    Passing nothing reproduces this project's original behavior exactly:
+    output/outer_shell.svg, BURN=0.08, blue cut / red engrave.
+    """
+    name = config.resolve_provider(provider)
+    provider_cfg = config.PROVIDERS[name]
+    output_path = Path(provider_cfg["output_dir"])
     output_path.mkdir(parents=True, exist_ok=True)
     output_file = output_path / "outer_shell.svg"
 
-    shell = OuterShell()
+    shell = OuterShell(provider=name)
     shell.parseArgs([
         "--output", str(output_file),
         "--thickness", str(MATERIAL_THICKNESS),
-        "--burn", str(BURN),
+        "--burn", str(provider_cfg["burn"]),
         "--reference", "0",
         "--FingerJoint_play", str(FINGER_PLAY_RELATIVE),
     ])

--- a/tests/test_ponoko_export.py
+++ b/tests/test_ponoko_export.py
@@ -1,0 +1,322 @@
+"""Ponoko export mode tests: run `python -m faxbox.ponoko` (subprocess, same
+PYTHONPATH-forcing pattern as conftest.py's `regenerate_svgs` fixture and
+test_layout.py's own `sheets` fixture) and check the emitted
+output/ponoko/sheet_*.svg files against the Ponoko order requirements: sheets
+within Ponoko's published birch-plywood workable area, only Ponoko's two
+colors present (no gray reference text, no <text> elements at all), the
+right part count (21 NYCR parts + 1 turn button + 1 self-calibration
+coupon = 23), engrave content only where DESIGN.md places it, the
+kerf-square coupon at true nominal 10.0mm, and provider BURN actually
+changing drawn geometry relative to the NYCR default.
+
+This fixture is deliberately separate from conftest.py's `regenerate_svgs`
+(NYCR-only) and test_layout.py's `sheets` (NYCR-only) fixtures -- Ponoko
+generation is only triggered by tests in THIS file explicitly requesting the
+`ponoko_sheets` fixture below, never as a side effect of running the rest of
+the suite.
+
+See faxbox/config.py's PROVIDERS/PONOKO_* constants for the verified-2026-07-07
+source URLs behind every Ponoko-specific number asserted here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+import svgpathtools
+
+import svg_utils as su
+from faxbox import config as c
+from faxbox import layout as fl
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = REPO_ROOT / "output"
+PONOKO_DIR = OUTPUT_DIR / "ponoko"
+
+PONOKO_CFG = c.PROVIDERS["ponoko"]
+NYCR_CFG = c.PROVIDERS["nycr"]
+
+
+# =============================================================================
+# Fixture: regenerate the Ponoko export explicitly (never a side effect of
+# any other test file running)
+# =============================================================================
+
+@pytest.fixture(scope="session")
+def ponoko_sheets(regenerate_svgs):
+    """Regenerate the NYCR default sources (regenerate_svgs, from
+    conftest.py -- needed by test_burn_actually_changes_drawn_geometry
+    below, which compares against the NYCR shell), then run
+    `python -m faxbox.ponoko` as a subprocess -- exactly what a human
+    ordering from Ponoko would run -- and return the resulting
+    output/ponoko/sheet_*.svg paths in sheet-number order."""
+    subprocess.run(
+        [sys.executable, "-m", "faxbox.ponoko"],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    paths = sorted(PONOKO_DIR.glob("sheet_*.svg"), key=lambda p: int(p.stem.split("_")[1]))
+    assert paths, "faxbox.ponoko produced no output/ponoko/sheet_*.svg files"
+    return paths
+
+
+# =============================================================================
+# Piece identification on ponoko sheets: layout._emit_piece_group always
+# stamps a `data-part="<source>: <label>"` attribute on each piece's <g>,
+# regardless of whether that piece's <text> label was stripped (which it is,
+# for every Ponoko piece -- config.PONOKO_STRIP_LABELS) -- so pieces are
+# still individually identifiable without relying on visible text.
+# =============================================================================
+
+class SheetPiece:
+    def __init__(self, label: str, bbox: "su.BBox", colors: set[str], has_text: bool):
+        self.label = label
+        self.bbox = bbox
+        self.colors = colors
+        self.has_text = has_text
+
+
+def _sheet_pieces(sheet_path: Path) -> list[SheetPiece]:
+    root = ET.parse(sheet_path).getroot()
+    pieces: list[SheetPiece] = []
+    for g in root.findall(f"{su.SVG_NS}g"):
+        path_els = [p for p in g.findall(f"{su.SVG_NS}path") if p.get("d")]
+        if not path_els:
+            continue
+        xs: list[float] = []
+        ys: list[float] = []
+        colors: set[str] = set()
+        for p in path_els:
+            x0, x1, y0, y1 = svgpathtools.parse_path(p.get("d")).bbox()
+            xs += [x0, x1]
+            ys += [y0, y1]
+            colors.add(su.normalize_color(p.get("stroke")))
+        texts = g.findall(f"{su.SVG_NS}text")
+        pieces.append(
+            SheetPiece(
+                label=g.get("data-part", g.get("id", "")),
+                bbox=su.BBox(xmin=min(xs), xmax=max(xs), ymin=min(ys), ymax=max(ys)),
+                colors=colors,
+                has_text=bool(texts),
+            )
+        )
+    return pieces
+
+
+def _all_sheet_pieces(sheets: list[Path]) -> list[SheetPiece]:
+    pieces: list[SheetPiece] = []
+    for sheet in sheets:
+        pieces.extend(_sheet_pieces(sheet))
+    return pieces
+
+
+# =============================================================================
+# Sheets within Ponoko's published birch-plywood workable area
+# (790mm x 384mm -- see config.PONOKO_SHEET_WIDTH/HEIGHT for the source URL)
+# =============================================================================
+
+def test_ponoko_sheets_within_size_limit(ponoko_sheets):
+    tol = 0.05
+    for sheet in ponoko_sheets:
+        width, height = su.get_svg_dimensions_mm(sheet)
+        assert width <= PONOKO_CFG["sheet_width"] + tol, (
+            f"{sheet.name} width {width}mm exceeds Ponoko's {PONOKO_CFG['sheet_width']}mm limit"
+        )
+        assert height <= PONOKO_CFG["sheet_height"] + tol, (
+            f"{sheet.name} height {height}mm exceeds Ponoko's {PONOKO_CFG['sheet_height']}mm limit"
+        )
+
+
+def test_ponoko_kept_to_three_sheets(ponoko_sheets):
+    """Not a hard Ponoko requirement, but price scales with material -- the
+    re-nest was designed to fit in 3 sheets (see README 'Ordering from
+    Ponoko'); assert that stays true so a future geometry change that
+    silently spills onto a 4th sheet gets caught here."""
+    assert len(ponoko_sheets) == 3, f"expected 3 Ponoko sheets, got {len(ponoko_sheets)}"
+
+
+# =============================================================================
+# Only Ponoko's two colors present anywhere -- no gray reference text
+# (there IS no text at all), no stray colors
+# =============================================================================
+
+def test_ponoko_sheets_have_no_text_elements(ponoko_sheets):
+    for sheet in ponoko_sheets:
+        pieces = _sheet_pieces(sheet)
+        assert pieces, f"{sheet.name}: no pieces found"
+        offenders = [p.label for p in pieces if p.has_text]
+        assert not offenders, f"{sheet.name}: pieces still carry <text>: {offenders}"
+
+
+def test_ponoko_sheets_use_only_the_two_ponoko_colors(ponoko_sheets):
+    allowed = {"blue", "red"}
+    for sheet in ponoko_sheets:
+        offenders = []
+        for piece in _sheet_pieces(sheet):
+            bad = piece.colors - allowed
+            if bad:
+                offenders.append((piece.label, bad))
+        assert not offenders, f"{sheet.name}: non-Ponoko colors found: {offenders}"
+
+
+def test_ponoko_sheets_no_gray_anywhere(ponoko_sheets):
+    """Defensive, independent of the no-<text> check above: no path or
+    element anywhere in a Ponoko sheet should carry the NYCR gray reference-
+    label color (rgb(128,128,128))."""
+    for sheet in ponoko_sheets:
+        text = sheet.read_text()
+        assert "128,128,128" not in text, f"{sheet.name}: found NYCR gray reference-label color"
+
+
+# =============================================================================
+# Part count: 21 NYCR parts (8 shell + 12 drawer + 1 lid) + 1 turn button +
+# 1 self-calibration coupon = 23
+# =============================================================================
+
+def test_ponoko_part_count_matches(ponoko_sheets):
+    pieces = _all_sheet_pieces(ponoko_sheets)
+    assert len(pieces) == fl.PONOKO_EXPECTED_PARTS + fl.PONOKO_EXPECTED_COUPONS
+
+    by_source = Counter(p.label.split(":", 1)[0] for p in pieces)
+    assert by_source["Shell"] == 8
+    assert by_source["Drawer 1"] == 6
+    assert by_source["Drawer 2"] == 6
+    assert by_source["Lid"] == 1
+    assert by_source["Hardware"] == 1
+    assert by_source["Calibration"] == 1
+
+
+def test_ponoko_no_overlapping_pieces(ponoko_sheets):
+    for sheet in ponoko_sheets:
+        pieces = _sheet_pieces(sheet)
+        offenders = []
+        for i in range(len(pieces)):
+            for j in range(i + 1, len(pieces)):
+                if pieces[i].bbox.overlaps(pieces[j].bbox):
+                    offenders.append((pieces[i].label, pieces[j].label))
+        assert not offenders, f"overlapping piece bboxes in {sheet.name}: {offenders}"
+
+
+# =============================================================================
+# Engrave (red) content only where DESIGN.md places it: the right wall's
+# "FAX MACHINE" text and each drawer's faceplate registration outline --
+# same rule test_laser_requirements.py enforces for the NYCR default.
+# =============================================================================
+
+def test_ponoko_engrave_only_on_right_wall_and_faceplates(ponoko_sheets):
+    pieces = _all_sheet_pieces(ponoko_sheets)
+    red_labels = {p.label for p in pieces if "red" in p.colors}
+    assert red_labels == {"Shell: Right Wall", "Drawer 1: Faceplate", "Drawer 2: Faceplate"}
+
+
+# =============================================================================
+# Kerf square: drawn tool path at EXACT nominal 10.0mm (burn-neutral), same
+# principle as the NYCR kerf coupon -- see calibration.py's
+# PonokoCalibrationCoupon docstring.
+# =============================================================================
+
+def test_ponoko_kerf_square_at_exact_nominal(ponoko_sheets):
+    square_holes = []
+    for sheet in ponoko_sheets:
+        for piece in su.get_pieces(sheet):
+            square_holes += [h for h in piece.holes if h.bbox.dims_match(10.0, 10.0, tol=0.5)]
+    assert len(square_holes) == 1, (
+        f"expected exactly 1 ~10x10mm kerf-square hole across all Ponoko sheets, found {len(square_holes)}"
+    )
+    hole = square_holes[0]
+    assert abs(hole.bbox.width - 10.0) <= 0.01, f"kerf square width {hole.bbox.width} != 10.0 nominal"
+    assert abs(hole.bbox.height - 10.0) <= 0.01, f"kerf square height {hole.bbox.height} != 10.0 nominal"
+
+
+def test_ponoko_magnet_gauge_holes_present(ponoko_sheets):
+    """4 magnet press-fit gauge holes (5.5/5.65/5.8/5.95mm), burn-
+    compensated with the Ponoko provider's own burn -- see
+    calibration.PONOKO_MAGNET_DIAMETERS. Scoped to the Calibration coupon
+    piece's own bbox: the real parts also carry ~5.65mm magnet holes (the
+    divider's 2 + each drawer Back's 1 = 4 more), which must NOT be
+    counted here."""
+    from faxbox import calibration as cal
+
+    expected_diams = sorted(cal.PONOKO_MAGNET_DIAMETERS)
+    drawn_expected = sorted(d - 2 * PONOKO_CFG["burn"] for d in expected_diams)
+
+    # Locate the Calibration coupon's bbox via its <g data-part=...> stamp.
+    coupon_bboxes = [
+        p.bbox
+        for sheet in ponoko_sheets
+        for p in _sheet_pieces(sheet)
+        if p.label.startswith("Calibration")
+    ]
+    assert len(coupon_bboxes) == 1, f"expected exactly 1 Calibration piece, found {len(coupon_bboxes)}"
+    coupon_bbox = coupon_bboxes[0]
+
+    gauge_holes = []
+    for sheet in ponoko_sheets:
+        for piece in su.get_pieces(sheet):
+            gauge_holes += [
+                h for h in piece.holes
+                if 4.5 <= h.bbox.width <= 6.5
+                and h.bbox.dims_match(h.bbox.width, h.bbox.width, tol=0.05)
+                and coupon_bbox.contains(h.bbox, tol=0.2)
+            ]
+    assert len(gauge_holes) == 4, f"expected 4 magnet gauge holes on the coupon, found {len(gauge_holes)}"
+    measured = sorted(h.bbox.width for h in gauge_holes)
+    for m, expected in zip(measured, drawn_expected):
+        assert abs(m - expected) <= 0.05, (
+            f"gauge hole measured {m:.3f}mm, expected ~{expected:.3f}mm (nominal - 2*ponoko_burn)"
+        )
+
+
+# =============================================================================
+# Provider BURN is actually applied: a finger-jointed piece's drawn bbox
+# (both axes jointed -- e.g. Shell's "Bottom" panel, all 4 edges 'f') grows
+# by exactly 2*(ponoko_burn - nycr_burn) per axis relative to the NYCR
+# default, since each of the piece's two opposite jointed edges shifts its
+# tab tip outward by (ponoko_burn - nycr_burn) -- verified empirically
+# against the actual generator output before being encoded as an exact
+# assertion here (not assumed from Boxes.py internals).
+# =============================================================================
+
+def test_burn_actually_changes_drawn_geometry(ponoko_sheets):
+    nycr_shell = OUTPUT_DIR / "outer_shell.svg"
+    ponoko_shell = PONOKO_DIR / "outer_shell.svg"
+    assert nycr_shell.exists(), "regenerate_svgs should have produced output/outer_shell.svg"
+    assert ponoko_shell.exists(), "faxbox.ponoko should have produced output/ponoko/outer_shell.svg"
+
+    nycr_piece = su.find_piece_by_label(su.design_pieces(nycr_shell), "Bottom")
+    ponoko_piece = su.find_piece_by_label(su.design_pieces(ponoko_shell), "Bottom")
+    assert nycr_piece is not None and ponoko_piece is not None
+
+    expected_delta = 2 * (PONOKO_CFG["burn"] - NYCR_CFG["burn"])
+    assert expected_delta > 0, "test assumes Ponoko's burn is larger than NYCR's default (0.10 > 0.08)"
+
+    width_delta = ponoko_piece.bbox.width - nycr_piece.bbox.width
+    height_delta = ponoko_piece.bbox.height - nycr_piece.bbox.height
+    assert abs(width_delta - expected_delta) <= 0.01, (
+        f"Bottom panel width delta {width_delta:.4f}mm != expected {expected_delta:.4f}mm "
+        "(2 * (ponoko_burn - nycr_burn)) -- provider BURN may not be reaching the generator"
+    )
+    assert abs(height_delta - expected_delta) <= 0.01, (
+        f"Bottom panel height delta {height_delta:.4f}mm != expected {expected_delta:.4f}mm "
+        "(2 * (ponoko_burn - nycr_burn)) -- provider BURN may not be reaching the generator"
+    )
+
+
+# =============================================================================
+# The NYCR default path is untouched: output/*.svg (not output/ponoko/*)
+# still exists and is what conftest.py's regenerate_svgs always produces.
+# =============================================================================
+
+def test_nycr_default_output_dir_unaffected(ponoko_sheets):
+    assert (OUTPUT_DIR / "outer_shell.svg").exists()
+    assert (OUTPUT_DIR / "drawer.svg").exists()
+    assert (OUTPUT_DIR / "lids.svg").exists()
+    # The Ponoko run must not have written anything into the plain output/
+    # directory itself (only output/ponoko/).
+    assert not (OUTPUT_DIR / "calibration_coupon.svg").exists()


### PR DESCRIPTION
## What

Adds an opt-in **Ponoko export mode** so the box can be mail-ordered from ponoko.com, behind a provider abstraction (`config.PROVIDERS = {"nycr": ..., "ponoko": ...}`) selected via `FAXBOX_PROVIDER=ponoko` (or `python -m faxbox.ponoko`). **The NYC Resistor path stays the default and is byte-for-byte unchanged** — verified by diffing regenerated outputs against a `main` worktree (identical modulo Boxes.py's embedded run timestamps; the `sheet_*.svg` files layout.py writes are exactly identical). All 188 pre-existing tests untouched and green.

## Verified Ponoko rules (live fetches, 2026-07-07 — URLs also encoded as comments in `config.py`)

| Rule | Verified value | Source |
|---|---|---|
| Color convention | **Blue stroke = cut, Red stroke = line/vector engrave** (gray fill = area engrave, unused here) | help.ponoko.com/en/articles/2688732-how-should-i-specify-laser-actions |
| Birch-ply kerf | **0.20mm** → provider BURN = 0.10 (per-side) | ponoko.com/materials/birch-plywood |
| Max sheet vs. design area | raw sheet 795×395mm, but **max design area 790×384mm** — nested within the smaller figure | help.ponoko.com/en/articles/2688726-what-size-can-i-make-my-part-what-material-sizes-are-available |
| Min element spacing | ~1mm (project keeps its existing 10mm margin / 5mm spacing) | help.ponoko.com/en/articles/2688741-how-do-i-design-for-highest-quality |
| Text | must be outlined or "will not be read" → **labels stripped entirely** (outlined names would engrave onto visible faces) | help.ponoko.com/en/articles/2688477-what-design-software-file-type-should-i-use |

Note: an earlier research pass claimed red=cut/blue=engrave — that was wrong and was caught by an independent re-fetch of Ponoko's own help article before being encoded. The current verified convention happens to match this project's existing NYCR colors.

## Output

`output/ponoko/sheet_{1,2,3}.svg` — **3 sheets** (price scales with material; the NYCR sheet 2 at ~549×434mm exceeded Ponoko's 384mm limit, so everything re-nests):

- sheet_1: **783.1 × 354.1mm**
- sheet_2: **789.2 × 338.1mm**
- sheet_3: **733.9 × 73.7mm**

Contents: all **22 real parts** (21 NYCR parts + the turn button, standalone on the NYCR path) **+ 1 self-calibration coupon** (burn-neutral 10.0mm kerf square + 4-hole magnet press-fit gauge row) nested into spare space — the first order is the test cut, since Ponoko has no scrap-coupon step. Calibration loop documented in README ("Ordering from Ponoko"): `PONOKO_BURN = (measured − 10.0) / 2`.

## Test evidence

New `tests/test_ponoko_export.py` (12 tests; Ponoko generation gated behind an explicit fixture, never a side effect of the rest of the suite):

- sheets within 790×384mm
- only blue/red strokes; **zero `<text>` elements**; no gray anywhere
- part count = 23 (8 shell + 12 drawer + 1 lid + 1 turn button + 1 coupon), no overlapping bboxes
- engrave-red appears on exactly {Right Wall, Faceplate ×2}
- kerf square at exact nominal 10.0mm (burn-neutral)
- magnet gauge holes drawn at nominal − 2×0.10 (burn-compensated), scoped to the coupon so the real parts' magnet holes aren't miscounted
- **provider BURN provably applied**: Shell Bottom bbox grows by exactly 2×(0.10−0.08) per jointed axis vs. the NYCR output

Full suite: **200 passed** (188 existing + 12 new). Sheets also rendered to PNG and visually checked: no overlaps, correct colors, no text, coupon present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvRaq1ibcFkT1fSc7P8E8W